### PR TITLE
Port over and cross-link docs from IntelliJ Elixir implementation

### DIFF
--- a/lumen/src/beam/mod.rs
+++ b/lumen/src/beam/mod.rs
@@ -1,3 +1,25 @@
+//! BEAM is the file format used in `.beam` files by the BEAM VM.
+//!
+//! The BEAM format is a binary chunked file format containing multiple sections.  It starts with
+//! the magic file constant `FOR1`, which is based on the `FORM` header used in the original
+//! [Interchange File Format (IFF)](https://en.wikipedia.org/wiki/Interchange_File_Format) that the
+//! BEAM file format is based.
+//!
+//! After the magic file constant, the format follows normal
+//! [Type-Length-Value (TLV)](https://en.wikipedia.org/wiki/Type-length-value) rules, and so
+//! it lists the size of rest of the file as a `u32`.
+//!
+//! After the the length, the first chunk is `BEAM`, which contains all other chunks.
+//!
+//! ## References
+//!
+//! * [BEAM Wisdom - BEAM File Format](http://beam-wisdoms.clau.se/en/latest/indepth-beam-file.html#)
+//! * [The BEAM Book - The BEAM File Format](https://happi.github.io/theBeamBook/#BEAM_files)
+//!
+//! ## Alternative Implementations
+//!
+//! * [org.elixir_lang.beam.Beam in IntelliJ Elixir](https://github.com/KronicDeth/intellij-elixir/blob/master/src/org/elixir_lang/beam/Beam.kt) in Kotlin
+
 pub mod reader;
 
 pub use self::reader::chunk;

--- a/lumen/src/beam/reader/beam_file.rs
+++ b/lumen/src/beam/reader/beam_file.rs
@@ -40,6 +40,9 @@ impl<C: Chunk> BeamFile<C> {
         self.chunks.insert(*chunk.id(), chunk);
     }
     /// Returns all chunks in the order they were encountered in the origin BEAM file
+    ///
+    /// ## Alternative Implementations
+    /// - [`org.elixir_lang.beam.Beam#chunkCollection` in IntelliJ Elixir](https://github.com/KronicDeth/intellij-elixir/blob/2f5c826040681e258e98c3e2f02b25985cd0766b/src/org/elixir_lang/beam/Beam.kt#L70) in Kotlin.
     pub fn chunks(&self) -> Vec<&C> {
         let mut result: Vec<&C> = Vec::new();
         for id in &self.order {
@@ -63,10 +66,17 @@ impl<C: Chunk> BeamFile<C> {
     ///         other =>
     ///           assert!(false, "assertion failed: expected Some(AtomChunk {{ atoms: _, is_unicode: false }}), got: {:?}", other)
     ///     }
+    ///
+    /// ## Alternative Implementations
+    /// - [`org.elixir_lang.beam.Beam#chunk` in IntelliJ Elixir](https://github.com/KronicDeth/intellij-elixir/blob/2f5c826040681e258e98c3e2f02b25985cd0766b/src/org/elixir_lang/beam/Beam.kt#L68-L69) in Kotlin.
     pub fn get_chunk(&self, id: &Id) -> Option<&C> {
         self.chunks.get(id)
     }
+
     /// Returns whichever chunk is the atom chunk, if it exists
+    ///
+    /// ## Alternative Implementations
+    /// - [`org.elixir_lang.beam.Beam#atoms` in IntelliJ Elixir](https://github.com/KronicDeth/intellij-elixir/blob/2f5c826040681e258e98c3e2f02b25985cd0766b/src/org/elixir_lang/beam/Beam.kt#L63-L65) in Kotlin.
     pub fn atoms(&self) -> Option<&C> {
         match self.get_chunk(b"Atom") {
             Some(c) => Some(c),

--- a/lumen/src/beam/reader/chunk/aux.rs
+++ b/lumen/src/beam/reader/chunk/aux.rs
@@ -15,6 +15,8 @@ impl Header {
             data_size: data_size,
         }
     }
+    /// Alternative Implementations
+    /// - [In `org.elixir_lang.bean.chunk.Chunk.from` in IntelliJ Elixir](https://github.com/KronicDeth/intellij-elixir/blob/2f5c826040681e258e98c3e2f02b25985cd0766b/src/org/elixir_lang/beam/chunk/Chunk.java#L36-L40) in Java.
     pub fn decode<R: std::io::Read>(mut reader: R) -> std::io::Result<Self> {
         let mut id = [0; 4];
         reader.read_exact(&mut id)?;
@@ -28,6 +30,8 @@ impl Header {
     }
 }
 
+/// ## Alternative Implementations
+/// - [In `org.elixir_lang.bean.chunk.Chunk.from` in IntelliJ Elixir](https://github.com/KronicDeth/intellij-elixir/blob/2f5c826040681e258e98c3e2f02b25985cd0766b/src/org/elixir_lang/beam/chunk/Chunk.java#L45) in Java.
 pub fn padding_size(data_size: u32) -> u32 {
     (4 - data_size % 4) % 4
 }

--- a/lumen/src/beam/reader/parts.rs
+++ b/lumen/src/beam/reader/parts.rs
@@ -21,6 +21,9 @@ pub struct Atom {
 }
 
 /// An imported function.
+///
+/// ## Alternative Implementations
+/// - [`org.elixir_lang.beam.chunk.imports.Import` in IntelliJ Elixir](https://github.com/KronicDeth/intellij-elixir/blob/2f5c826040681e258e98c3e2f02b25985cd0766b/src/org/elixir_lang/beam/chunk/imports/Import.kt) in Kotlin
 #[derive(Debug, PartialEq, Eq)]
 pub struct Import {
     pub module: AtomId,


### PR DESCRIPTION
Since most of the types are private outside of `lumen`, you'll need to run `cargo doc -p lumen --document-private-items` to see the docs that were added in the rendered HTML.  The `--document-private-items` seems to be an accepted standard to allow docs on private stuff for development teams that isn't in the public API.

# Changelog
## Enhancements
* Expanded the BEAM file format docs (`lumen::beam` from the information I gathered making the dissassembler for IntelliJ Elixir.