### PR TITLE
Replace rug::Integer with num_bigint::BigInt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,8 +673,9 @@ dependencies = [
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "liblumen_arena 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rug 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,6 +740,15 @@ dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1627,6 +1637,7 @@ dependencies = [
 "checksum nom 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9c349f68f25f596b9f44cf0e7c69752a5c633b0550c3ff849518bfba0233774a"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
+"checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"

--- a/lumen_runtime/Cargo.toml
+++ b/lumen_runtime/Cargo.toml
@@ -19,7 +19,8 @@ lazy_static = "1.2"
 libc = "0.2"
 liblumen_arena = { path = "../liblumen_arena" }
 log = "0.4"
-rug = "1.3"
+num-bigint = "0.2.2"
+num-traits = "0.2.6"
 signal-hook = "0.1"
 xdg = "2.1"
 

--- a/lumen_runtime/src/binary/heap.rs
+++ b/lumen_runtime/src/binary/heap.rs
@@ -381,6 +381,8 @@ mod tests {
     mod iter {
         use super::*;
 
+        use std::convert::TryInto;
+
         #[test]
         fn without_elements() {
             let mut process: Process = Default::default();
@@ -390,7 +392,7 @@ mod tests {
             assert_eq!(binary.iter().count(), 0);
 
             let size_integer: Integer = binary.size();
-            let size_usize: usize = size_integer.into();
+            let size_usize: usize = size_integer.try_into().unwrap();
 
             assert_eq!(binary.iter().count(), size_usize);
         }
@@ -407,7 +409,7 @@ mod tests {
             assert_eq!(binary.iter().count(), 1);
 
             let size_integer: Integer = binary.size();
-            let size_usize: usize = size_integer.into();
+            let size_usize: usize = size_integer.try_into().unwrap();
 
             assert_eq!(binary.iter().count(), size_usize);
         }

--- a/lumen_runtime/src/integer/big.rs
+++ b/lumen_runtime/src/integer/big.rs
@@ -1,18 +1,53 @@
-use crate::term::{Tag, Term};
+use std::convert::TryFrom;
+
+use num_bigint::{BigInt, Sign::*};
+
+use crate::term::{BadArgument, Tag, Term};
 
 pub struct Integer {
     #[allow(dead_code)]
     header: Term,
-    pub inner: rug::Integer,
+    pub inner: BigInt,
 }
 
 impl Integer {
-    pub fn new(inner: rug::Integer) -> Self {
+    pub fn new(inner: BigInt) -> Self {
         Integer {
             header: Term {
                 tagged: Tag::BigInteger as usize,
             },
             inner,
         }
+    }
+}
+
+impl TryFrom<Integer> for usize {
+    type Error = BadArgument;
+
+    fn try_from(integer: Integer) -> Result<usize, BadArgument> {
+        big_int_to_usize(&integer.inner)
+    }
+}
+
+impl TryFrom<&Integer> for usize {
+    type Error = BadArgument;
+
+    fn try_from(integer_ref: &Integer) -> Result<usize, BadArgument> {
+        big_int_to_usize(&integer_ref.inner)
+    }
+}
+
+pub fn big_int_to_usize(big_int: &BigInt) -> Result<usize, BadArgument> {
+    match big_int.sign() {
+        Plus => {
+            let (_, bytes) = big_int.to_bytes_be();
+            let integer_usize = bytes
+                .iter()
+                .fold(0_usize, |acc, byte| (acc << 8) | (*byte as usize));
+
+            Ok(integer_usize)
+        }
+        NoSign => Ok(0),
+        Minus => Err(BadArgument),
     }
 }

--- a/lumen_runtime/src/process.rs
+++ b/lumen_runtime/src/process.rs
@@ -3,6 +3,8 @@
 use std::cmp::Ordering;
 use std::sync::{Arc, RwLock};
 
+use num_bigint::BigInt;
+
 use liblumen_arena::TypedArena;
 
 use crate::atom::{self, Existence};
@@ -61,9 +63,9 @@ impl Process {
         unsafe { &*pointer }
     }
 
-    pub fn rug_integer_to_big_integer(&self, rug_integer: rug::Integer) -> &'static big::Integer {
+    pub fn num_bigint_big_in_to_big_integer(&self, big_int: BigInt) -> &'static big::Integer {
         let pointer =
-            self.big_integer_arena.alloc(big::Integer::new(rug_integer)) as *const big::Integer;
+            self.big_integer_arena.alloc(big::Integer::new(big_int)) as *const big::Integer;
 
         unsafe { &*pointer }
     }
@@ -286,7 +288,7 @@ impl IntoProcess<Term> for bool {
     }
 }
 
-impl IntoProcess<Term> for rug::Integer {
+impl IntoProcess<Term> for BigInt {
     fn into_process(self, mut process: &mut Process) -> Term {
         let integer: integer::Integer = self.into();
 

--- a/lumen_runtime/src/tuple.rs
+++ b/lumen_runtime/src/tuple.rs
@@ -298,6 +298,8 @@ mod tests {
     mod iter {
         use super::*;
 
+        use std::convert::TryInto;
+
         use crate::process::IntoProcess;
 
         #[test]
@@ -307,7 +309,7 @@ mod tests {
 
             assert_eq!(tuple.iter().count(), 0);
 
-            let size_usize: usize = tuple.size().into();
+            let size_usize: usize = tuple.size().try_into().unwrap();
 
             assert_eq!(tuple.iter().count(), size_usize);
         }
@@ -319,7 +321,7 @@ mod tests {
 
             assert_eq!(tuple.iter().count(), 1);
 
-            let size_usize: usize = tuple.size().into();
+            let size_usize: usize = tuple.size().try_into().unwrap();
 
             assert_eq!(tuple.iter().count(), size_usize);
         }


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Replace `rug::Integer` with `num_bigint::BigInt`.  `rug::Integer` is dependent on `gmp-mpfr-sys` `v1.1.10`, which doesn't work for `wasm-unknown-unknown`:
  ```
  error: failed to run custom build command for `gmp-mpfr-sys v1.1.10`
    process didn't exit successfully: `/Users/luke.imhoff/github/lumen/lumen/target/release/build/gmp-mpfr-sys-9790fefe7274603e/build-script-build` (exit code: 101)
    --- stdout
    cargo:rerun-if-env-changed=GMP_MPFR_SYS_CACHE
    
    --- stderr
    thread 'main' panicked at 'assertion failed: `(left == right)`
      left: `"x86_64-apple-darwin"`,
     right: `"wasm32-unknown-unknown"`: cross compilation is not supported', /Users/luke.imhoff/.cargo/registry/src/github.com-1ecc6299db9ec823/gmp-mpfr-sys-1.1.10/build.rs:74:5
    note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
  ```