### PR TITLE
assert_bad_argument!

### DIFF
--- a/lumen_runtime/src/otp/erlang/tests/abs.rs
+++ b/lumen_runtime/src/otp/erlang/tests/abs.rs
@@ -9,11 +9,7 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::abs(atom_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::abs(atom_term, &mut process), process);
 }
 
 #[test]
@@ -21,11 +17,7 @@ fn with_heap_binary_is_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[0], &mut process);
 
-    assert_eq_in_process!(
-        erlang::abs(heap_binary_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::abs(heap_binary_term, &mut process), process);
 }
 
 #[test]
@@ -35,22 +27,14 @@ fn with_subbinary_is_bad_argument() {
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
 
-    assert_eq_in_process!(
-        erlang::abs(subbinary_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::abs(subbinary_term, &mut process), process);
 }
 
 #[test]
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
-        erlang::abs(Term::EMPTY_LIST, &mut process),
-        Err(bad_argument!()),
-        Default::default()
-    );
+    assert_bad_argument!(erlang::abs(Term::EMPTY_LIST, &mut process), process);
 }
 
 #[test]
@@ -58,11 +42,7 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
-        erlang::abs(list_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::abs(list_term, &mut process), process);
 }
 
 #[test]
@@ -183,11 +163,7 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
-        erlang::abs(local_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::abs(local_pid_term, &mut process), process);
 }
 
 #[test]
@@ -195,11 +171,7 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::abs(external_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::abs(external_pid_term, &mut process), process);
 }
 
 #[test]
@@ -207,9 +179,5 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::abs(tuple_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::abs(tuple_term, &mut process), process);
 }

--- a/lumen_runtime/src/otp/erlang/tests/append_element.rs
+++ b/lumen_runtime/src/otp/erlang/tests/append_element.rs
@@ -7,9 +7,8 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::append_element(atom_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -18,9 +17,8 @@ fn with_atom_is_bad_argument() {
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::append_element(Term::EMPTY_LIST, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -30,9 +28,8 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::append_element(list_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -42,13 +39,12 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term: Term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::append_element(
             small_integer_term,
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -60,9 +56,8 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::append_element(big_integer_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -72,9 +67,8 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term: Term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::append_element(float_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -84,9 +78,8 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::append_element(local_pid_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -96,13 +89,12 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::append_element(
             external_pid_term,
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -141,7 +133,7 @@ fn with_tuple_with_index_at_size_return_tuples_with_new_element_at_end() {
             &mut process
         )),
         process
-    )
+    );
 }
 
 #[test]
@@ -149,9 +141,8 @@ fn with_heap_binary_is_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::append_element(heap_binary_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -163,9 +154,8 @@ fn with_subbinary_is_bad_argument() {
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::append_element(subbinary_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
-    )
+    );
 }

--- a/lumen_runtime/src/otp/erlang/tests/atom_to_binary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/atom_to_binary.rs
@@ -10,9 +10,8 @@ fn with_atom_without_encoding_atom_returns_bad_argument() {
     let atom_name = "😈";
     let atom_term = Term::str_to_atom(atom_name, Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_binary(atom_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -25,9 +24,8 @@ fn with_atom_with_invalid_encoding_atom_returns_bad_argument() {
     let invalid_encoding_atom_term =
         Term::str_to_atom("invalid_encoding", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_binary(atom_term, invalid_encoding_atom_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -64,9 +62,8 @@ fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_binary(Term::EMPTY_LIST, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -77,9 +74,8 @@ fn with_list_is_bad_argument() {
     let list_term = list_term(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_binary(list_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -90,9 +86,8 @@ fn with_small_integer_is_bad_argument() {
     let small_integer_term = 0usize.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_binary(small_integer_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -105,9 +100,8 @@ fn with_big_integer_is_bad_argument() {
         .into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_binary(big_integer_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -118,9 +112,8 @@ fn with_float_is_bad_argument() {
     let float_term = 1.0.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_binary(float_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -131,9 +124,8 @@ fn with_local_pid_is_bad_argument() {
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_binary(local_pid_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -144,9 +136,8 @@ fn with_external_pid_is_bad_argument() {
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_binary(external_pid_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -160,9 +151,8 @@ fn with_tuple_is_bad_argument() {
     );
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_binary(tuple_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -173,9 +163,8 @@ fn with_heap_binary_is_bad_argument() {
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_binary(heap_binary_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -188,9 +177,8 @@ fn with_subbinary_is_bad_argument() {
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_binary(subbinary_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/atom_to_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/atom_to_list.rs
@@ -10,9 +10,8 @@ fn with_atom_without_encoding_atom_returns_bad_argument() {
     let atom_name = "😈🤘";
     let atom_term = Term::str_to_atom(atom_name, Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_list(atom_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -25,9 +24,8 @@ fn with_atom_with_invalid_encoding_atom_returns_bad_argument() {
     let invalid_encoding_atom_term =
         Term::str_to_atom("invalid_encoding", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_list(atom_term, invalid_encoding_atom_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -88,9 +86,8 @@ fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_list(Term::EMPTY_LIST, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -101,9 +98,8 @@ fn with_list_is_bad_argument() {
     let list_term = list_term(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_list(list_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -114,9 +110,8 @@ fn with_small_integer_is_bad_argument() {
     let small_integer_term = 0usize.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_list(small_integer_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -129,9 +124,8 @@ fn with_big_integer_is_bad_argument() {
         .into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_list(big_integer_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -142,9 +136,8 @@ fn with_float_is_bad_argument() {
     let float_term = 1.0.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_list(float_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -155,9 +148,8 @@ fn with_local_pid_is_bad_argument() {
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_list(local_pid_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -168,9 +160,8 @@ fn with_external_pid_is_bad_argument() {
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_list(external_pid_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -184,9 +175,8 @@ fn with_tuple_is_bad_argument() {
     );
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_list(tuple_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -197,9 +187,8 @@ fn with_heap_binary_is_bad_argument() {
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_list(heap_binary_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -212,9 +201,8 @@ fn with_subbinary_is_bad_argument() {
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::atom_to_list(subbinary_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/binary_byte_range_to_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_byte_range_to_list.rs
@@ -9,14 +9,13 @@ fn with_atom_returns_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_byte_range_to_list(
             atom_term,
             2.into_process(&mut process),
             3.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -25,14 +24,13 @@ fn with_atom_returns_bad_argument() {
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_byte_range_to_list(
             Term::EMPTY_LIST,
             2.into_process(&mut process),
             3.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -42,14 +40,13 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_byte_range_to_list(
             list_term,
             2.into_process(&mut process),
             3.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -59,14 +56,13 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term = 0usize.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_byte_range_to_list(
             small_integer_term,
             2.into_process(&mut process),
             3.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -78,14 +74,13 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_byte_range_to_list(
             big_integer_term,
             2.into_process(&mut process),
             3.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -95,14 +90,13 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_byte_range_to_list(
             float_term,
             2.into_process(&mut process),
             3.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -112,14 +106,13 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_byte_range_to_list(
             local_pid_term,
             2.into_process(&mut process),
             3.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -129,14 +122,13 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_byte_range_to_list(
             external_pid_term,
             2.into_process(&mut process),
             3.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -146,14 +138,13 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_byte_range_to_list(
             tuple_term,
             2.into_process(&mut process),
             3.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -205,14 +196,13 @@ fn with_heap_binary_with_start_greater_than_stop_returns_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[0, 1, 2], &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_byte_range_to_list(
             heap_binary_term,
             3.into_process(&mut process),
             2.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -270,14 +260,13 @@ fn with_subbinary_with_start_greater_than_stop_returns_bad_argument() {
     let binary_term = Term::slice_to_binary(&[128, 0, 129, 0b0000_0000], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 1, 3, 0, &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_byte_range_to_list(
             subbinary_term,
             3.into_process(&mut process),
             2.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/binary_in_base_to_integer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_in_base_to_integer.rs
@@ -10,9 +10,8 @@ fn with_atom_returns_bad_argument() {
     let atom_term = Term::str_to_atom("😈🤘", Existence::DoNotCare, &mut process).unwrap();
     let base_term: Term = 16.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_in_base_to_integer(atom_term, base_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -22,9 +21,8 @@ fn with_empty_list_returns_bad_argument() {
     let mut process: Process = Default::default();
     let base_term: Term = 16.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_in_base_to_integer(Term::EMPTY_LIST, base_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -35,9 +33,8 @@ fn with_list_is_bad_argument() {
     let list_term = list_term(&mut process);
     let base_term: Term = 16.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_in_base_to_integer(list_term, base_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -48,9 +45,8 @@ fn with_small_integer_is_bad_argument() {
     let small_integer_term = 0usize.into_process(&mut process);
     let base_term: Term = 16.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_in_base_to_integer(small_integer_term, base_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -63,9 +59,8 @@ fn with_big_integer_is_bad_argument() {
         .into_process(&mut process);
     let base_term: Term = 16.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_in_base_to_integer(big_integer_term, base_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -76,9 +71,8 @@ fn with_float_is_bad_argument() {
     let float_term = 1.0.into_process(&mut process);
     let base_term: Term = 16.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_in_base_to_integer(float_term, base_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -89,9 +83,8 @@ fn with_local_pid_is_bad_argument() {
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let base_term: Term = 16.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_in_base_to_integer(local_pid_term, base_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -102,9 +95,8 @@ fn with_external_pid_is_bad_argument() {
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let base_term: Term = 16.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_in_base_to_integer(external_pid_term, base_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -115,9 +107,8 @@ fn with_tuple_is_bad_argument() {
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
     let base_term: Term = 16.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_in_base_to_integer(tuple_term, base_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/binary_options_to_term.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_options_to_term.rs
@@ -14,9 +14,8 @@ mod with_safe {
             &mut process,
         );
 
-        assert_eq_in_process!(
+        assert_bad_argument!(
             erlang::binary_options_to_term(binary_term, options, &mut process),
-            Err(bad_argument!()),
             process
         );
 
@@ -41,9 +40,8 @@ mod with_safe {
             &mut process,
         );
 
-        assert_eq_in_process!(
+        assert_bad_argument!(
             erlang::binary_options_to_term(binary_term, options, &mut process),
-            Err(bad_argument!()),
             process
         );
 
@@ -70,9 +68,8 @@ mod with_safe {
             &mut process,
         );
 
-        assert_eq_in_process!(
+        assert_bad_argument!(
             erlang::binary_options_to_term(binary_term, options, &mut process),
-            Err(bad_argument!()),
             process
         );
 
@@ -97,9 +94,8 @@ mod with_safe {
             &mut process,
         );
 
-        assert_eq_in_process!(
+        assert_bad_argument!(
             erlang::binary_options_to_term(binary_term, options, &mut process),
-            Err(bad_argument!()),
             process
         );
 

--- a/lumen_runtime/src/otp/erlang/tests/binary_part.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_part.rs
@@ -9,14 +9,13 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(
             atom_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -25,14 +24,13 @@ fn with_atom_is_bad_argument() {
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(
             Term::EMPTY_LIST,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -42,14 +40,13 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(
             list_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -59,14 +56,13 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term: Term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(
             small_integer_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -78,14 +74,13 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(
             big_integer_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -95,14 +90,13 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term: Term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(
             float_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -112,14 +106,13 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(
             local_pid_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -129,14 +122,13 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(
             external_pid_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -149,14 +141,13 @@ fn with_tuple_is_bad_argument() {
         &mut process,
     );
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(
             tuple_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -171,9 +162,8 @@ fn with_heap_binary_without_integer_start_without_integer_length_returns_bad_arg
     );
     let length_term = Term::str_to_atom("all", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(heap_binary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -185,9 +175,8 @@ fn with_heap_binary_without_integer_start_with_integer_length_returns_bad_argume
     let start_term = 0.into_process(&mut process);
     let length_term = Term::str_to_atom("all", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(heap_binary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -199,9 +188,8 @@ fn with_heap_binary_with_integer_start_without_integer_length_returns_bad_argume
     let start_term = 0.into_process(&mut process);
     let length_term = Term::str_to_atom("all", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(heap_binary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -213,9 +201,8 @@ fn with_heap_binary_with_negative_start_with_valid_length_returns_bad_argument()
     let start_term = (-1isize).into_process(&mut process);
     let length_term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(heap_binary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -227,9 +214,8 @@ fn with_heap_binary_with_start_greater_than_size_with_non_negative_length_return
     let start_term = 1.into_process(&mut process);
     let length_term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(heap_binary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -242,9 +228,8 @@ fn with_heap_binary_with_start_less_than_size_with_negative_length_past_start_re
     let start_term = 0.into_process(&mut process);
     let length_term = (-1isize).into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(heap_binary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -256,9 +241,8 @@ fn with_heap_binary_with_start_less_than_size_with_positive_length_past_end_retu
     let start_term = 0.into_process(&mut process);
     let length_term = 2.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(heap_binary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -359,9 +343,8 @@ fn with_subbinary_without_integer_start_without_integer_length_returns_bad_argum
     );
     let length_term = Term::str_to_atom("all", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(subbinary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -375,9 +358,8 @@ fn with_subbinary_without_integer_start_with_integer_length_returns_bad_argument
     let start_term = 0.into_process(&mut process);
     let length_term = Term::str_to_atom("all", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(subbinary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -391,9 +373,8 @@ fn with_subbinary_with_integer_start_without_integer_length_returns_bad_argument
     let start_term = 0.into_process(&mut process);
     let length_term = Term::str_to_atom("all", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(subbinary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -407,9 +388,8 @@ fn with_subbinary_with_negative_start_with_valid_length_returns_bad_argument() {
     let start_term = (-1isize).into_process(&mut process);
     let length_term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(subbinary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -423,9 +403,8 @@ fn with_subbinary_with_start_greater_than_size_with_non_negative_length_returns_
     let start_term = 1.into_process(&mut process);
     let length_term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(subbinary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -439,9 +418,8 @@ fn with_subbinary_with_start_less_than_size_with_negative_length_past_start_retu
     let start_term = 0.into_process(&mut process);
     let length_term = (-1isize).into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(subbinary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -455,9 +433,8 @@ fn with_subbinary_with_start_less_than_size_with_positive_length_past_end_return
     let start_term = 0.into_process(&mut process);
     let length_term = 2.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_part(subbinary_term, start_term, length_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_atom.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_atom.rs
@@ -10,9 +10,8 @@ fn with_atom_is_bad_argument() {
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_atom(atom_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -22,9 +21,8 @@ fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_atom(Term::EMPTY_LIST, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -35,9 +33,8 @@ fn with_list_is_bad_argument() {
     let list_term = list_term(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_atom(list_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -48,9 +45,8 @@ fn with_small_integer_is_bad_argument() {
     let small_integer_term = 0usize.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_atom(small_integer_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -63,9 +59,8 @@ fn with_big_integer_is_bad_argument() {
         .into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_atom(big_integer_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -76,9 +71,8 @@ fn with_float_is_bad_argument() {
     let float_term = 1.0.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_atom(float_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -89,9 +83,8 @@ fn with_local_pid_is_bad_argument() {
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_atom(local_pid_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -102,9 +95,8 @@ fn with_external_pid_is_bad_argument() {
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_atom(external_pid_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -118,9 +110,8 @@ fn with_tuple_is_bad_argument() {
     );
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_atom(tuple_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -130,9 +121,8 @@ fn with_heap_binary_without_encoding_atom_returns_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_atom(heap_binary_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -144,9 +134,8 @@ fn with_heap_binary_with_invalid_encoding_atom_returns_bad_argument() {
     let invalid_encoding_term =
         Term::str_to_atom("invalid_encoding", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_atom(heap_binary_term, invalid_encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -164,17 +153,17 @@ fn with_heap_binary_with_valid_encoding_returns_atom() {
     assert_eq_in_process!(
         erlang::binary_to_atom(heap_binary_term, latin1_atom_term, &mut process),
         Ok(atom_term),
-        &mut process
+        process
     );
     assert_eq_in_process!(
         erlang::binary_to_atom(heap_binary_term, unicode_atom_term, &mut process),
         Ok(atom_term),
-        &mut process
+        process
     );
     assert_eq_in_process!(
         erlang::binary_to_atom(heap_binary_term, utf8_atom_term, &mut process),
         Ok(atom_term),
-        &mut process
+        process
     );
 }
 
@@ -187,11 +176,10 @@ fn with_subbinary_with_bit_count_returns_bad_argument() {
     let unicode_atom_term =
         Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_atom(subbinary_term, unicode_atom_term, &mut process),
-        Err(bad_argument!()),
-        &mut process
-    )
+        process
+    );
 }
 
 #[test]
@@ -205,6 +193,6 @@ fn with_subbinary_without_bit_count_returns_atom_with_bytes() {
     assert_eq_in_process!(
         erlang::binary_to_atom(subbinary_term, unicode_atom_term, &mut process),
         Term::str_to_atom("🤘", Existence::DoNotCare, &mut process),
-        &mut process
+        process
     )
 }

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_existing_atom.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_existing_atom.rs
@@ -10,9 +10,8 @@ fn with_atom_is_bad_argument() {
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(atom_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -22,9 +21,8 @@ fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(Term::EMPTY_LIST, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -35,9 +33,8 @@ fn with_list_is_bad_argument() {
     let list_term = list_term(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(list_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -48,9 +45,8 @@ fn with_small_integer_is_bad_argument() {
     let small_integer_term = 0usize.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(small_integer_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -63,9 +59,8 @@ fn with_big_integer_is_bad_argument() {
         .into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(big_integer_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -76,9 +71,8 @@ fn with_float_is_bad_argument() {
     let float_term = 1.0.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(float_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -92,9 +86,8 @@ fn with_tuple_is_bad_argument() {
     );
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(tuple_term, encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -104,13 +97,12 @@ fn with_heap_binary_without_encoding_atom_returns_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(
             heap_binary_term,
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -122,9 +114,8 @@ fn with_heap_binary_with_invalid_encoding_atom_returns_bad_argument() {
     let invalid_encoding_term =
         Term::str_to_atom("invalid_encoding", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(heap_binary_term, invalid_encoding_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -138,20 +129,17 @@ fn with_heap_binary_with_valid_encoding_without_existing_atom_returns_atom() {
         Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
     let utf8_atom_term = Term::str_to_atom("utf8", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(heap_binary_term, latin1_atom_term, &mut process),
-        Err(bad_argument!()),
-        &mut process
+        process
     );
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(heap_binary_term, unicode_atom_term, &mut process),
-        Err(bad_argument!()),
-        &mut process
+        process
     );
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(heap_binary_term, utf8_atom_term, &mut process),
-        Err(bad_argument!()),
-        &mut process
+        process
     );
 }
 
@@ -168,17 +156,17 @@ fn with_heap_binary_with_valid_encoding_with_existing_atom_returns_atom() {
     assert_eq_in_process!(
         erlang::binary_to_existing_atom(heap_binary_term, latin1_atom_term, &mut process),
         Ok(atom_term),
-        &mut process
+        process
     );
     assert_eq_in_process!(
         erlang::binary_to_existing_atom(heap_binary_term, unicode_atom_term, &mut process),
         Ok(atom_term),
-        &mut process
+        process
     );
     assert_eq_in_process!(
         erlang::binary_to_existing_atom(heap_binary_term, utf8_atom_term, &mut process),
         Ok(atom_term),
-        &mut process
+        process
     );
 }
 
@@ -191,10 +179,9 @@ fn with_subbinary_with_bit_count_returns_bad_argument() {
     let unicode_atom_term =
         Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(subbinary_term, unicode_atom_term, &mut process),
-        Err(bad_argument!()),
-        &mut process
+        process
     )
 }
 
@@ -206,10 +193,9 @@ fn with_subbinary_without_bit_count_without_existing_atom_returns_bad_argument()
     let unicode_atom_term =
         Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_existing_atom(subbinary_term, unicode_atom_term, &mut process),
-        Err(bad_argument!()),
-        &mut process
+        process
     )
 }
 
@@ -225,6 +211,6 @@ fn with_subbinary_without_bit_count_with_existing_atom_returns_atom_with_bytes()
     assert_eq_in_process!(
         erlang::binary_to_existing_atom(subbinary_term, unicode_atom_term, &mut process),
         atom_term,
-        &mut process
+        process
     )
 }

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_float.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_float.rs
@@ -9,20 +9,15 @@ fn with_atom_returns_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("😈🤘", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::binary_to_float(atom_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_float(atom_term, &mut process), process);
 }
 
 #[test]
 fn with_empty_list_returns_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_float(Term::EMPTY_LIST, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -32,11 +27,7 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
-        erlang::binary_to_float(list_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_float(list_term, &mut process), process);
 }
 
 #[test]
@@ -44,9 +35,8 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term = 0usize.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_float(small_integer_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -58,9 +48,8 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_float(big_integer_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -70,11 +59,7 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::binary_to_float(float_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_float(float_term, &mut process), process);
 }
 
 #[test]
@@ -82,9 +67,8 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_float(local_pid_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -94,9 +78,8 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_float(external_pid_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -106,11 +89,7 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::binary_to_float(tuple_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_float(tuple_term, &mut process), process);
 }
 
 #[test]
@@ -118,9 +97,8 @@ fn with_heap_binary_with_integer_returns_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary("1".as_bytes(), &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_float(heap_binary_term, &mut process),
-        Err(bad_argument!()),
         process
     )
 }
@@ -157,9 +135,8 @@ fn with_heap_binary_with_less_than_min_f64_returns_bad_argument() {
     let heap_binary_term =
             Term::slice_to_binary("-1797693134862315700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0".as_bytes(), &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_float(heap_binary_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -170,9 +147,8 @@ fn with_heap_binary_with_greater_than_max_f64_returns_bad_argument() {
     let heap_binary_term =
             Term::slice_to_binary("17976931348623157000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0".as_bytes(), &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_float(heap_binary_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -1163,9 +1139,8 @@ fn with_subbinary_with_less_than_min_f64_returns_bag_argument() {
     );
     let subbinary_term = Term::subbinary(heap_binary_term, 0, 1, 313, 0, &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_float(subbinary_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -1495,9 +1470,8 @@ fn with_subbinary_with_greater_than_max_f64_returns_bad_argument() {
     );
     let subbinary_term = Term::subbinary(heap_binary_term, 0, 1, 313, 0, &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_float(subbinary_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_integer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_integer.rs
@@ -9,20 +9,15 @@ fn with_atom_returns_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("😈🤘", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::binary_to_integer(atom_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_integer(atom_term, &mut process), process);
 }
 
 #[test]
 fn with_empty_list_returns_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_integer(Term::EMPTY_LIST, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -32,11 +27,7 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
-        erlang::binary_to_integer(list_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_integer(list_term, &mut process), process);
 }
 
 #[test]
@@ -44,9 +35,8 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term = 0usize.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_integer(small_integer_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -58,9 +48,8 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_integer(big_integer_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -70,11 +59,7 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::binary_to_integer(float_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_integer(float_term, &mut process), process);
 }
 
 #[test]
@@ -82,11 +67,7 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::binary_to_integer(tuple_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_integer(tuple_term, &mut process), process);
 }
 
 #[test]
@@ -176,9 +157,8 @@ fn with_heap_binary_with_non_decimal_returns_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary("FF".as_bytes(), &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_integer(heap_binary_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -374,9 +354,8 @@ fn with_subbinary_with_non_decimal_returns_bad_argument() {
     let heap_binary_term = Term::slice_to_binary(&[163, 35, 0b000_0000], &mut process);
     let subbinary_term = Term::subbinary(heap_binary_term, 0, 1, 2, 0, &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_integer(subbinary_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_list.rs
@@ -9,20 +9,15 @@ fn with_atom_returns_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::binary_to_list(atom_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_list(atom_term, &mut process), process);
 }
 
 #[test]
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_list(Term::EMPTY_LIST, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -32,11 +27,7 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
-        erlang::binary_to_list(list_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_list(list_term, &mut process), process);
 }
 
 #[test]
@@ -44,9 +35,8 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term = 0usize.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_list(small_integer_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -58,9 +48,8 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_list(big_integer_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -70,11 +59,7 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::binary_to_list(float_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_list(float_term, &mut process), process);
 }
 
 #[test]
@@ -82,9 +67,8 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_list(local_pid_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -94,9 +78,8 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_list(external_pid_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -106,11 +89,7 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::binary_to_list(tuple_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_list(tuple_term, &mut process), process);
 }
 
 #[test]
@@ -162,9 +141,8 @@ fn with_subbinary_with_bit_count_returns_bad_argument() {
     let binary_term = Term::slice_to_binary(&[128, 0, 129, 0b0000_0000], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 0, 3, 1, &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_list(subbinary_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_term.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_term.rs
@@ -9,20 +9,15 @@ fn with_atom_returns_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::binary_to_term(atom_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_term(atom_term, &mut process), process);
 }
 
 #[test]
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_term(Term::EMPTY_LIST, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -32,11 +27,7 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
-        erlang::binary_to_term(list_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_term(list_term, &mut process), process);
 }
 
 #[test]
@@ -44,9 +35,8 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term = 0usize.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_term(small_integer_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -58,9 +48,8 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_term(big_integer_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -70,11 +59,7 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::binary_to_term(float_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_term(float_term, &mut process), process);
 }
 
 #[test]
@@ -82,9 +67,8 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_term(local_pid_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -94,9 +78,8 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::binary_to_term(external_pid_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -106,11 +89,7 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::binary_to_term(tuple_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::binary_to_term(tuple_term, &mut process), process);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bit_size.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bit_size.rs
@@ -7,22 +7,14 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::bit_size(atom_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bit_size(atom_term, &mut process), process);
 }
 
 #[test]
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
-        erlang::bit_size(Term::EMPTY_LIST, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bit_size(Term::EMPTY_LIST, &mut process), process);
 }
 
 #[test]
@@ -30,11 +22,7 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
-        erlang::bit_size(list_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bit_size(list_term, &mut process), process);
 }
 
 #[test]
@@ -42,11 +30,7 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term: Term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::bit_size(small_integer_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bit_size(small_integer_term, &mut process), process);
 }
 
 #[test]
@@ -56,11 +40,7 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::bit_size(big_integer_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bit_size(big_integer_term, &mut process), process);
 }
 
 #[test]
@@ -68,11 +48,7 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::bit_size(float_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bit_size(float_term, &mut process), process);
 }
 
 #[test]
@@ -80,11 +56,7 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
-        erlang::bit_size(local_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bit_size(local_pid_term, &mut process), process);
 }
 
 #[test]
@@ -92,11 +64,7 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::bit_size(external_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bit_size(external_pid_term, &mut process), process);
 }
 
 #[test]
@@ -104,11 +72,7 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::bit_size(tuple_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bit_size(tuple_term, &mut process), process);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bitstring_to_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bitstring_to_list.rs
@@ -7,20 +7,15 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::bitstring_to_list(atom_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bitstring_to_list(atom_term, &mut process), process);
 }
 
 #[test]
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::bitstring_to_list(Term::EMPTY_LIST, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -30,11 +25,7 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
-        erlang::bitstring_to_list(list_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bitstring_to_list(list_term, &mut process), process);
 }
 
 #[test]
@@ -42,9 +33,8 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term: Term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::bitstring_to_list(small_integer_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -56,9 +46,8 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::bitstring_to_list(big_integer_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -68,11 +57,7 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::bitstring_to_list(float_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bitstring_to_list(float_term, &mut process), process);
 }
 
 #[test]
@@ -80,9 +65,8 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::bitstring_to_list(local_pid_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -92,9 +76,8 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::bitstring_to_list(external_pid_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -104,11 +87,7 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::bitstring_to_list(tuple_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::bitstring_to_list(tuple_term, &mut process), process);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/byte_size.rs
+++ b/lumen_runtime/src/otp/erlang/tests/byte_size.rs
@@ -7,22 +7,14 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::byte_size(atom_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::byte_size(atom_term, &mut process), process);
 }
 
 #[test]
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
-        erlang::byte_size(Term::EMPTY_LIST, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::byte_size(Term::EMPTY_LIST, &mut process), process);
 }
 
 #[test]
@@ -30,11 +22,7 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
-        erlang::byte_size(list_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::byte_size(list_term, &mut process), process);
 }
 
 #[test]
@@ -42,11 +30,7 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term: Term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::byte_size(small_integer_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::byte_size(small_integer_term, &mut process), process);
 }
 
 #[test]
@@ -56,11 +40,7 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::byte_size(big_integer_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::byte_size(big_integer_term, &mut process), process);
 }
 
 #[test]
@@ -68,11 +48,7 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::byte_size(float_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::byte_size(float_term, &mut process), process);
 }
 
 #[test]
@@ -80,11 +56,7 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
-        erlang::byte_size(local_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::byte_size(local_pid_term, &mut process), process);
 }
 
 #[test]
@@ -92,11 +64,7 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::byte_size(external_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::byte_size(external_pid_term, &mut process), process);
 }
 
 #[test]
@@ -104,11 +72,7 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::byte_size(tuple_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::byte_size(tuple_term, &mut process), process);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/ceil.rs
+++ b/lumen_runtime/src/otp/erlang/tests/ceil.rs
@@ -7,22 +7,14 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::ceil(atom_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::ceil(atom_term, &mut process), process);
 }
 
 #[test]
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
-        erlang::ceil(Term::EMPTY_LIST, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::ceil(Term::EMPTY_LIST, &mut process), process);
 }
 
 #[test]
@@ -30,11 +22,7 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
-        erlang::ceil(list_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::ceil(list_term, &mut process), process);
 }
 
 #[test]
@@ -88,11 +76,7 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
-        erlang::ceil(local_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::ceil(local_pid_term, &mut process), process);
 }
 
 #[test]
@@ -100,11 +84,7 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::ceil(external_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::ceil(external_pid_term, &mut process), process);
 }
 
 #[test]
@@ -112,11 +92,7 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::ceil(tuple_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::ceil(tuple_term, &mut process), process);
 }
 
 #[test]
@@ -124,11 +100,7 @@ fn with_heap_binary_is_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[1], &mut process);
 
-    assert_eq_in_process!(
-        erlang::ceil(heap_binary_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::ceil(heap_binary_term, &mut process), process);
 }
 
 #[test]
@@ -137,9 +109,5 @@ fn with_subbinary_is_bad_argument() {
     let binary_term = Term::slice_to_binary(&[0, 1], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 1, 0, 1, 0, &mut process);
 
-    assert_eq_in_process!(
-        erlang::ceil(subbinary_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::ceil(subbinary_term, &mut process), process);
 }

--- a/lumen_runtime/src/otp/erlang/tests/convert_time_unit.rs
+++ b/lumen_runtime/src/otp/erlang/tests/convert_time_unit.rs
@@ -7,9 +7,8 @@ fn with_atom_is_bad_argument() {
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::convert_time_unit(atom_term, from_unit_term, to_unit_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -20,9 +19,8 @@ fn with_empty_list_is_bad_argument() {
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::convert_time_unit(Term::EMPTY_LIST, from_unit_term, to_unit_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -34,9 +32,8 @@ fn with_list_is_bad_argument() {
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::convert_time_unit(list_term, from_unit_term, to_unit_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -54,25 +51,23 @@ mod with_small_integer {
             Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
         let invalid_unit_term = Term::str_to_atom("s", Existence::DoNotCare, &mut process).unwrap();
 
-        assert_eq_in_process!(
+        assert_bad_argument!(
             erlang::convert_time_unit(
                 small_integer_term,
                 valid_unit_term,
                 invalid_unit_term,
                 &mut process,
             ),
-            Err(bad_argument!()),
             process
         );
 
-        assert_eq_in_process!(
+        assert_bad_argument!(
             erlang::convert_time_unit(
                 small_integer_term,
                 invalid_unit_term,
                 valid_unit_term,
                 &mut process,
             ),
-            Err(bad_argument!()),
             process
         );
     }
@@ -693,25 +688,23 @@ mod with_big_integer {
             Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
         let invalid_unit_term = Term::str_to_atom("s", Existence::DoNotCare, &mut process).unwrap();
 
-        assert_eq_in_process!(
+        assert_bad_argument!(
             erlang::convert_time_unit(
                 big_integer_term,
                 valid_unit_term,
                 invalid_unit_term,
                 &mut process,
             ),
-            Err(bad_argument!()),
             process
         );
 
-        assert_eq_in_process!(
+        assert_bad_argument!(
             erlang::convert_time_unit(
                 big_integer_term,
                 invalid_unit_term,
                 valid_unit_term,
                 &mut process,
             ),
-            Err(bad_argument!()),
             process
         );
     }
@@ -1447,9 +1440,8 @@ fn with_float_returns_bad_argument() {
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::convert_time_unit(float_term, from_unit_term, to_unit_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -1461,9 +1453,8 @@ fn with_local_pid_is_bad_argument() {
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::convert_time_unit(local_pid_term, from_unit_term, to_unit_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -1475,14 +1466,13 @@ fn with_external_pid_is_bad_argument() {
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::convert_time_unit(
             external_pid_term,
             from_unit_term,
             to_unit_term,
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -1494,9 +1484,8 @@ fn with_tuple_is_bad_argument() {
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::convert_time_unit(tuple_term, from_unit_term, to_unit_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -1508,9 +1497,8 @@ fn with_heap_binary_is_bad_argument() {
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::convert_time_unit(heap_binary_term, from_unit_term, to_unit_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -1523,9 +1511,8 @@ fn with_subbinary_is_bad_argument() {
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::convert_time_unit(subbinary_term, from_unit_term, to_unit_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/delete_element.rs
+++ b/lumen_runtime/src/otp/erlang/tests/delete_element.rs
@@ -7,9 +7,8 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::delete_element(atom_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -18,9 +17,8 @@ fn with_atom_is_bad_argument() {
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::delete_element(Term::EMPTY_LIST, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -30,9 +28,8 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::delete_element(list_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -42,13 +39,12 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term: Term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::delete_element(
             small_integer_term,
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -60,9 +56,8 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::delete_element(big_integer_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -72,9 +67,8 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::delete_element(float_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -84,9 +78,8 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::delete_element(local_pid_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -96,13 +89,12 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::delete_element(
             external_pid_term,
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -122,9 +114,8 @@ fn with_tuple_without_small_integer_index_is_bad_argument() {
     let invalid_index_term = Term::arity(index);
 
     assert_ne!(invalid_index_term.tag(), Tag::SmallInteger);
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::delete_element(tuple_term, invalid_index_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 
@@ -146,9 +137,8 @@ fn with_tuple_without_index_in_range_is_bad_argument() {
     let mut process: Process = Default::default();
     let empty_tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::delete_element(empty_tuple_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -180,9 +170,8 @@ fn with_heap_binary_is_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::delete_element(heap_binary_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -194,9 +183,8 @@ fn with_subbinary_is_bad_argument() {
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::delete_element(subbinary_term, 0.into_process(&mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/element.rs
+++ b/lumen_runtime/src/otp/erlang/tests/element.rs
@@ -7,9 +7,8 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::element(atom_term, 0.into_process(&mut process)),
-        Err(bad_argument!()),
         process
     );
 }
@@ -18,9 +17,8 @@ fn with_atom_is_bad_argument() {
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::element(Term::EMPTY_LIST, 0.into_process(&mut process)),
-        Err(bad_argument!()),
         process
     );
 }
@@ -30,9 +28,8 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::element(list_term, 0.into_process(&mut process)),
-        Err(bad_argument!()),
         process
     );
 }
@@ -42,9 +39,8 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term: Term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::element(small_integer_term, 0.into_process(&mut process)),
-        Err(bad_argument!()),
         process
     );
 }
@@ -56,9 +52,8 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::element(big_integer_term, 0.into_process(&mut process)),
-        Err(bad_argument!()),
         process
     );
 }
@@ -68,9 +63,8 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::element(float_term, 0.into_process(&mut process)),
-        Err(bad_argument!()),
         process
     );
 }
@@ -80,9 +74,8 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::element(local_pid_term, 0.into_process(&mut process)),
-        Err(bad_argument!()),
         process
     );
 }
@@ -92,9 +85,8 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::element(external_pid_term, 0.into_process(&mut process)),
-        Err(bad_argument!()),
         process
     );
 }
@@ -108,11 +100,7 @@ fn with_tuple_without_small_integer_index_is_bad_argument() {
     let invalid_index_term = Term::arity(index);
 
     assert_ne!(invalid_index_term.tag(), Tag::SmallInteger);
-    assert_eq_in_process!(
-        erlang::element(tuple_term, invalid_index_term),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::element(tuple_term, invalid_index_term), process);
 
     let valid_index_term: Term = index.into_process(&mut process);
 
@@ -129,9 +117,8 @@ fn with_tuple_without_index_in_range_is_bad_argument() {
     let mut process: Process = Default::default();
     let empty_tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::element(empty_tuple_term, 0.into_process(&mut process)),
-        Err(bad_argument!()),
         process
     );
 }
@@ -154,9 +141,8 @@ fn with_heap_binary_is_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::element(heap_binary_term, 0.into_process(&mut process)),
-        Err(bad_argument!()),
         process
     );
 }
@@ -168,9 +154,8 @@ fn with_subbinary_is_bad_argument() {
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::element(subbinary_term, 0.into_process(&mut process)),
-        Err(bad_argument!()),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/head.rs
+++ b/lumen_runtime/src/otp/erlang/tests/head.rs
@@ -7,18 +7,12 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(erlang::head(atom_term), Err(bad_argument!()), process);
+    assert_bad_argument!(erlang::head(atom_term), process);
 }
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let empty_list_term = Term::EMPTY_LIST;
-
-    assert_eq_in_process!(
-        erlang::head(empty_list_term),
-        Err(bad_argument!()),
-        Default::default()
-    );
+    assert_bad_argument!(erlang::head(Term::EMPTY_LIST), Default::default());
 }
 
 #[test]
@@ -35,11 +29,7 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::head(small_integer_term),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::head(small_integer_term), process);
 }
 
 #[test]
@@ -49,11 +39,7 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::head(big_integer_term),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::head(big_integer_term), process);
 }
 
 #[test]
@@ -61,7 +47,7 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(erlang::head(float_term), Err(bad_argument!()), process);
+    assert_bad_argument!(erlang::head(float_term), process);
 }
 
 #[test]
@@ -69,7 +55,7 @@ fn with_local_pid_is_bad_argument() {
     let process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(erlang::head(local_pid_term), Err(bad_argument!()), process);
+    assert_bad_argument!(erlang::head(local_pid_term), process);
 }
 
 #[test]
@@ -77,11 +63,7 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::head(external_pid_term),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::head(external_pid_term), process);
 }
 
 #[test]
@@ -89,7 +71,7 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(erlang::head(tuple_term), Err(bad_argument!()), process);
+    assert_bad_argument!(erlang::head(tuple_term), process);
 }
 
 #[test]
@@ -97,11 +79,7 @@ fn with_heap_binary_is_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::head(heap_binary_term),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::head(heap_binary_term), process);
 }
 
 #[test]
@@ -111,5 +89,5 @@ fn with_subbinary_is_bad_argument() {
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
 
-    assert_eq_in_process!(erlang::head(subbinary_term), Err(bad_argument!()), process);
+    assert_bad_argument!(erlang::head(subbinary_term), process);
 }

--- a/lumen_runtime/src/otp/erlang/tests/insert_element.rs
+++ b/lumen_runtime/src/otp/erlang/tests/insert_element.rs
@@ -7,14 +7,13 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::insert_element(
             atom_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -23,14 +22,13 @@ fn with_atom_is_bad_argument() {
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::insert_element(
             Term::EMPTY_LIST,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -40,14 +38,13 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::insert_element(
             list_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -57,14 +54,13 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::insert_element(
             small_integer_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -76,14 +72,13 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::insert_element(
             big_integer_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -93,14 +88,13 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::insert_element(
             float_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -110,14 +104,13 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::insert_element(
             local_pid_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -127,14 +120,13 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::insert_element(
             external_pid_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -150,14 +142,13 @@ fn with_tuple_without_small_integer_index_is_bad_argument() {
     let invalid_index_term = Term::arity(index);
 
     assert_ne!(invalid_index_term.tag(), Tag::SmallInteger);
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::insert_element(
             tuple_term,
             invalid_index_term,
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 
@@ -188,14 +179,13 @@ fn with_tuple_without_index_in_range_is_bad_argument() {
     let mut process: Process = Default::default();
     let empty_tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::insert_element(
             empty_tuple_term,
             1.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -252,14 +242,13 @@ fn with_heap_binary_is_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::insert_element(
             heap_binary_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -271,14 +260,13 @@ fn with_subbinary_is_bad_argument() {
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::insert_element(
             subbinary_term,
             0.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/length.rs
+++ b/lumen_runtime/src/otp/erlang/tests/length.rs
@@ -7,11 +7,7 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::length(atom_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::length(atom_term, &mut process), process);
 }
 
 #[test]
@@ -33,11 +29,7 @@ fn with_improper_list_is_bad_argument() {
     let tail_term = Term::str_to_atom("tail", Existence::DoNotCare, &mut process).unwrap();
     let improper_list_term = Term::cons(head_term, tail_term, &mut process);
 
-    assert_eq_in_process!(
-        erlang::length(improper_list_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::length(improper_list_term, &mut process), process);
 }
 
 #[test]
@@ -59,11 +51,7 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::length(small_integer_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::length(small_integer_term, &mut process), process);
 }
 
 #[test]
@@ -73,11 +61,7 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::length(big_integer_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::length(big_integer_term, &mut process), process);
 }
 
 #[test]
@@ -85,11 +69,7 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::length(float_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::length(float_term, &mut process), process);
 }
 
 #[test]
@@ -97,11 +77,7 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
-        erlang::length(local_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::length(local_pid_term, &mut process), process);
 }
 
 #[test]
@@ -109,11 +85,7 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::length(external_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::length(external_pid_term, &mut process), process);
 }
 
 #[test]
@@ -121,11 +93,7 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::length(tuple_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::length(tuple_term, &mut process), process);
 }
 
 #[test]
@@ -133,11 +101,7 @@ fn with_heap_binary_is_false() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::length(heap_binary_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::length(heap_binary_term, &mut process), process);
 }
 
 #[test]
@@ -147,9 +111,5 @@ fn with_subbinary_is_false() {
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
 
-    assert_eq_in_process!(
-        erlang::length(subbinary_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::length(subbinary_term, &mut process), process);
 }

--- a/lumen_runtime/src/otp/erlang/tests/list_to_pid.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_pid.rs
@@ -7,56 +7,42 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::list_to_pid(atom_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::list_to_pid(atom_term, &mut process), process);
 }
 
 #[test]
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
-        erlang::list_to_pid(Term::EMPTY_LIST, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::list_to_pid(Term::EMPTY_LIST, &mut process), process);
 }
 
 #[test]
 fn with_list_encoding_local_pid() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<", &mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<0", &mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<0.", &mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<0.1", &mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<0.1.", &mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<0.1.2", &mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 
@@ -69,12 +55,11 @@ fn with_list_encoding_local_pid() {
         process
     );
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(
             Term::str_to_char_list("<0.1.2>?", &mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -83,34 +68,28 @@ fn with_list_encoding_local_pid() {
 fn with_list_encoding_external_pid() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<", &mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<1", &mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<1.", &mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<1.2", &mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<1.2.", &mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<1.2.3", &mut process), &mut process),
-        Err(bad_argument!()),
         process
     );
 
@@ -123,12 +102,11 @@ fn with_list_encoding_external_pid() {
         process
     );
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(
             Term::str_to_char_list("<1.2.3>?", &mut process),
             &mut process
         ),
-        Err(bad_argument!()),
         process
     );
 }
@@ -138,9 +116,8 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(small_integer_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -152,11 +129,7 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::list_to_pid(big_integer_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::list_to_pid(big_integer_term, &mut process), process);
 }
 
 #[test]
@@ -164,11 +137,7 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::list_to_pid(float_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::list_to_pid(float_term, &mut process), process);
 }
 
 #[test]
@@ -176,11 +145,7 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
-        erlang::list_to_pid(local_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::list_to_pid(local_pid_term, &mut process), process);
 }
 
 #[test]
@@ -188,9 +153,8 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
+    assert_bad_argument!(
         erlang::list_to_pid(external_pid_term, &mut process),
-        Err(bad_argument!()),
         process
     );
 }
@@ -200,11 +164,7 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::list_to_pid(tuple_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::list_to_pid(tuple_term, &mut process), process);
 }
 
 #[test]
@@ -212,11 +172,7 @@ fn with_heap_binary_is_false() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::list_to_pid(heap_binary_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::list_to_pid(heap_binary_term, &mut process), process);
 }
 
 #[test]
@@ -226,9 +182,5 @@ fn with_subbinary_is_false() {
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
 
-    assert_eq_in_process!(
-        erlang::list_to_pid(subbinary_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::list_to_pid(subbinary_term, &mut process), process);
 }

--- a/lumen_runtime/src/otp/erlang/tests/size.rs
+++ b/lumen_runtime/src/otp/erlang/tests/size.rs
@@ -9,22 +9,14 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::size(atom_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::size(atom_term, &mut process), process);
 }
 
 #[test]
 fn with_empty_list_is_bad_argument() {
     let mut process: Process = Default::default();
 
-    assert_eq_in_process!(
-        erlang::size(Term::EMPTY_LIST, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::size(Term::EMPTY_LIST, &mut process), process);
 }
 
 #[test]
@@ -32,11 +24,7 @@ fn with_list_is_bad_argument() {
     let mut process: Process = Default::default();
     let list_term = list_term(&mut process);
 
-    assert_eq_in_process!(
-        erlang::size(list_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::size(list_term, &mut process), process);
 }
 
 #[test]
@@ -44,11 +32,7 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term = 0usize.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::size(small_integer_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::size(small_integer_term, &mut process), process);
 }
 
 #[test]
@@ -58,11 +42,7 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::size(big_integer_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::size(big_integer_term, &mut process), process);
 }
 
 #[test]
@@ -70,11 +50,7 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::size(float_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::size(float_term, &mut process), process);
 }
 
 #[test]
@@ -82,11 +58,7 @@ fn with_local_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(
-        erlang::size(local_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::size(local_pid_term, &mut process), process);
 }
 
 #[test]
@@ -94,11 +66,7 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::size(external_pid_term, &mut process),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::size(external_pid_term, &mut process), process);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/tail.rs
+++ b/lumen_runtime/src/otp/erlang/tests/tail.rs
@@ -7,18 +7,12 @@ fn with_atom_is_bad_argument() {
     let mut process: Process = Default::default();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
-    assert_eq_in_process!(erlang::tail(atom_term), Err(bad_argument!()), process);
+    assert_bad_argument!(erlang::tail(atom_term), process);
 }
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let empty_list_term = Term::EMPTY_LIST;
-
-    assert_eq_in_process!(
-        erlang::tail(empty_list_term),
-        Err(bad_argument!()),
-        Default::default()
-    );
+    assert_bad_argument!(erlang::tail(Term::EMPTY_LIST), Default::default());
 }
 
 #[test]
@@ -35,11 +29,7 @@ fn with_small_integer_is_bad_argument() {
     let mut process: Process = Default::default();
     let small_integer_term = 0.into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::tail(small_integer_term),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::tail(small_integer_term), process);
 }
 
 #[test]
@@ -49,11 +39,7 @@ fn with_big_integer_is_bad_argument() {
         .unwrap()
         .into_process(&mut process);
 
-    assert_eq_in_process!(
-        erlang::tail(big_integer_term),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::tail(big_integer_term), process);
 }
 
 #[test]
@@ -61,7 +47,7 @@ fn with_float_is_bad_argument() {
     let mut process: Process = Default::default();
     let float_term = 1.0.into_process(&mut process);
 
-    assert_eq_in_process!(erlang::tail(float_term), Err(bad_argument!()), process);
+    assert_bad_argument!(erlang::tail(float_term), process);
 }
 
 #[test]
@@ -69,7 +55,7 @@ fn with_local_pid_is_bad_argument() {
     let process: Process = Default::default();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
-    assert_eq_in_process!(erlang::tail(local_pid_term), Err(bad_argument!()), process);
+    assert_bad_argument!(erlang::tail(local_pid_term), process);
 }
 
 #[test]
@@ -77,11 +63,7 @@ fn with_external_pid_is_bad_argument() {
     let mut process: Process = Default::default();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
-    assert_eq_in_process!(
-        erlang::tail(external_pid_term),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::tail(external_pid_term), process);
 }
 
 #[test]
@@ -89,7 +71,7 @@ fn with_tuple_is_bad_argument() {
     let mut process: Process = Default::default();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
-    assert_eq_in_process!(erlang::tail(tuple_term), Err(bad_argument!()), process);
+    assert_bad_argument!(erlang::tail(tuple_term), process);
 }
 
 #[test]
@@ -97,11 +79,7 @@ fn with_heap_binary_is_bad_argument() {
     let mut process: Process = Default::default();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
-    assert_eq_in_process!(
-        erlang::tail(heap_binary_term),
-        Err(bad_argument!()),
-        process
-    );
+    assert_bad_argument!(erlang::tail(heap_binary_term), process);
 }
 
 #[test]
@@ -111,5 +89,5 @@ fn with_subbinary_is_bad_argument() {
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
 
-    assert_eq_in_process!(erlang::tail(subbinary_term), Err(bad_argument!()), process);
+    assert_bad_argument!(erlang::tail(subbinary_term), process);
 }

--- a/lumen_runtime/src/process.rs
+++ b/lumen_runtime/src/process.rs
@@ -294,6 +294,16 @@ macro_rules! assert_ne_in_process {
     });
 }
 
+#[macro_export]
+macro_rules! assert_bad_argument {
+    ($left:expr, $process:expr) => {{
+        assert_eq_in_process!($left, Err(bad_argument!()), $process)
+    }};
+    ($left:expr, $process:expr,) => {{
+        assert_eq_in_process!($left, Err(bad_argument!()), $process)
+    }};
+}
+
 /// Like `std::convert::Into`, but additionally takes `&mut Process` in case it is needed to
 /// lookup or create new values in the `Process`.
 pub trait IntoProcess<T> {


### PR DESCRIPTION
# Changelog
## Enhancements
* `assert_bad_argument!(call, process)`

  Shorter than `assert_eq_in_process(.., Err(BadArgument), process)` to the point that some asserts don't span multiple lines anymore.  It also makes it pop-out that bad argument is expected when the call being tested has to span multiple lines.