### PR TITLE
Multiple processes

### DIFF
--- a/lumen_runtime/src/binary.rs
+++ b/lumen_runtime/src/binary.rs
@@ -19,13 +19,9 @@ pub enum Binary<'a> {
 }
 
 impl<'a> Binary<'a> {
-    pub fn from_slice(bytes: &[u8], process: &mut Process) -> Self {
+    pub fn from_slice(bytes: &[u8], mut process: &mut Process) -> Self {
         // TODO use reference counted binaries for bytes.len() > 64
-        let heap_binary = heap::Binary::from_slice(
-            bytes,
-            &mut process.heap_binary_arena,
-            &mut process.byte_arena,
-        );
+        let heap_binary = heap::Binary::from_slice(bytes, &mut process);
 
         Binary::Heap(heap_binary)
     }

--- a/lumen_runtime/src/binary/sub.rs
+++ b/lumen_runtime/src/binary/sub.rs
@@ -387,9 +387,15 @@ mod tests {
     mod byte_iter {
         use super::*;
 
+        use std::sync::{Arc, RwLock};
+
+        use crate::environment::{self, Environment};
+
         #[test]
         fn is_double_ended() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             // <<1::1, 0, 1, 2>>
             let binary = Term::slice_to_binary(&[128, 0, 129, 0b0000_0000], &mut process);
             let subbinary = Binary::new(binary, 0, 1, 3, 0);

--- a/lumen_runtime/src/environment.rs
+++ b/lumen_runtime/src/environment.rs
@@ -1,21 +1,34 @@
 #![cfg_attr(not(test), allow(dead_code))]
 
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
 use crate::atom::{self, Existence};
 use crate::bad_argument::BadArgument;
+use crate::process::{self, Process};
+use crate::term::Term;
 
 pub struct Environment {
+    pid_counter: process::identifier::LocalCounter,
     atom_table: atom::Table,
+    pub process_by_pid_tagged: HashMap<usize, Arc<RwLock<Process>>>,
 }
 
 impl Environment {
     pub fn new() -> Environment {
         Environment {
             atom_table: atom::Table::new(),
+            pid_counter: Default::default(),
+            process_by_pid_tagged: HashMap::new(),
         }
     }
 
     pub fn atom_index_to_string(&self, atom_index: atom::Index) -> String {
         self.atom_table.name(atom_index)
+    }
+
+    pub fn next_pid(&mut self) -> Term {
+        self.pid_counter.next().into()
     }
 
     pub fn str_to_atom_index(
@@ -25,6 +38,30 @@ impl Environment {
     ) -> Result<atom::Index, BadArgument> {
         self.atom_table.str_to_index(name, existence)
     }
+}
+
+#[cfg(test)]
+impl Default for Environment {
+    fn default() -> Environment {
+        Environment::new()
+    }
+}
+
+pub fn process(environment_rw_lock: Arc<RwLock<Environment>>) -> Arc<RwLock<Process>> {
+    let process = Process::new(Arc::clone(&environment_rw_lock));
+    let pid = process.pid;
+    let process_rw_lock = Arc::new(RwLock::new(process));
+
+    if let Some(_) = environment_rw_lock
+        .write()
+        .unwrap()
+        .process_by_pid_tagged
+        .insert(pid.tagged, Arc::clone(&process_rw_lock))
+    {
+        panic!("Process already registerd with pid");
+    }
+
+    process_rw_lock
 }
 
 #[cfg(test)]

--- a/lumen_runtime/src/list.rs
+++ b/lumen_runtime/src/list.rs
@@ -181,11 +181,16 @@ mod tests {
     mod eq {
         use super::*;
 
+        use std::sync::{Arc, RwLock};
+
+        use crate::environment::{self, Environment};
         use crate::process::IntoProcess;
 
         #[test]
         fn with_proper() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let cons = Cons::new(0.into_process(&mut process), Term::EMPTY_LIST);
             let equal = Cons::new(0.into_process(&mut process), Term::EMPTY_LIST);
             let unequal = Cons::new(1.into_process(&mut process), Term::EMPTY_LIST);
@@ -197,7 +202,9 @@ mod tests {
 
         #[test]
         fn with_improper() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let cons = Cons::new(0.into_process(&mut process), 1.into_process(&mut process));
             let equal = Cons::new(0.into_process(&mut process), 1.into_process(&mut process));
             let unequal = Cons::new(1.into_process(&mut process), 0.into_process(&mut process));

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -558,6 +558,10 @@ pub fn list_to_pid(string: Term, mut process: &mut Process) -> Result<Term, BadA
     cons.to_pid(&mut process)
 }
 
+pub fn self_pid(process: &Process) -> Term {
+    process.pid
+}
+
 pub fn size(binary_or_tuple: Term, mut process: &mut Process) -> Result<Term, BadArgument> {
     match binary_or_tuple.tag() {
         Tag::Boxed => {

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-use std::cmp::Ordering;
-
 use crate::otp::erlang;
 
 mod abs;
@@ -34,6 +32,7 @@ mod is_list;
 mod is_tuple;
 mod length;
 mod list_to_pid;
+mod self_pid;
 mod size;
 mod tail;
 

--- a/lumen_runtime/src/otp/erlang/tests/abs.rs
+++ b/lumen_runtime/src/otp/erlang/tests/abs.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::abs(atom_term, &mut process), process);
@@ -14,7 +19,9 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0], &mut process);
 
     assert_bad_argument!(erlang::abs(heap_binary_term, &mut process), process);
@@ -22,7 +29,9 @@ fn with_heap_binary_is_bad_argument() {
 
 #[test]
 fn with_subbinary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
@@ -32,14 +41,18 @@ fn with_subbinary_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(erlang::abs(Term::EMPTY_LIST, &mut process), process);
 }
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(erlang::abs(list_term, &mut process), process);
@@ -47,7 +60,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_that_is_negative_returns_positive() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     let negative: isize = -1;
     let negative_term = negative.into_process(&mut process);
@@ -64,7 +79,9 @@ fn with_small_integer_that_is_negative_returns_positive() {
 
 #[test]
 fn with_small_integer_that_is_positive_returns_self() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let positive_term = 1usize.into_process(&mut process);
 
     assert_eq_in_process!(
@@ -76,7 +93,9 @@ fn with_small_integer_that_is_positive_returns_self() {
 
 #[test]
 fn with_big_integer_that_is_negative_returns_positive() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     let negative: isize = small::MIN - 1;
     let negative_term = negative.into_process(&mut process);
@@ -99,7 +118,9 @@ fn with_big_integer_that_is_negative_returns_positive() {
 
 #[test]
 fn with_big_integer_that_is_positive_return_self() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let positive_term: Term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -119,7 +140,9 @@ fn with_big_integer_that_is_positive_return_self() {
 
 #[test]
 fn with_float_that_is_negative_returns_positive() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     let negative = -1.0;
     let negative_term = negative.into_process(&mut process);
@@ -142,7 +165,9 @@ fn with_float_that_is_negative_returns_positive() {
 
 #[test]
 fn with_float_that_is_positive_return_self() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let positive_term: Term = 1.0.into_process(&mut process);
 
     assert_eq!(positive_term.tag(), Tag::Boxed);
@@ -160,7 +185,9 @@ fn with_float_that_is_positive_return_self() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(erlang::abs(local_pid_term, &mut process), process);
@@ -168,7 +195,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(erlang::abs(external_pid_term, &mut process), process);
@@ -176,7 +205,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::abs(tuple_term, &mut process), process);

--- a/lumen_runtime/src/otp/erlang/tests/append_element.rs
+++ b/lumen_runtime/src/otp/erlang/tests/append_element.rs
@@ -1,10 +1,16 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
+
+use crate::environment::{self, Environment};
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -15,7 +21,9 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::append_element(Term::EMPTY_LIST, 0.into_process(&mut process), &mut process),
@@ -25,7 +33,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(
@@ -36,7 +46,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term: Term = 0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -51,7 +63,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term: Term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -64,7 +78,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term: Term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -75,7 +91,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(
@@ -86,7 +104,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -101,7 +121,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_returns_tuple_with_new_element_at_end() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
         &[0.into_process(&mut process), 1.into_process(&mut process)],
         &mut process,
@@ -123,7 +145,9 @@ fn with_tuple_returns_tuple_with_new_element_at_end() {
 
 #[test]
 fn with_tuple_with_index_at_size_return_tuples_with_new_element_at_end() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[0.into_process(&mut process)], &mut process);
 
     assert_eq_in_process!(
@@ -138,7 +162,9 @@ fn with_tuple_with_index_at_size_return_tuples_with_new_element_at_end() {
 
 #[test]
 fn with_heap_binary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
     assert_bad_argument!(
@@ -149,7 +175,9 @@ fn with_heap_binary_is_bad_argument() {
 
 #[test]
 fn with_subbinary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/atom_to_binary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/atom_to_binary.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_without_encoding_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_name = "😈";
     let atom_term = Term::str_to_atom(atom_name, Existence::DoNotCare, &mut process).unwrap();
 
@@ -18,7 +23,9 @@ fn with_atom_without_encoding_atom_returns_bad_argument() {
 
 #[test]
 fn with_atom_with_invalid_encoding_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_name = "😈";
     let atom_term = Term::str_to_atom(atom_name, Existence::DoNotCare, &mut process).unwrap();
     let invalid_encoding_atom_term =
@@ -32,7 +39,9 @@ fn with_atom_with_invalid_encoding_atom_returns_bad_argument() {
 
 #[test]
 fn with_atom_with_encoding_atom_returns_name_in_binary() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_name = "😈";
     let atom_term = Term::str_to_atom(atom_name, Existence::DoNotCare, &mut process).unwrap();
     let latin1_atom_term = Term::str_to_atom("latin1", Existence::DoNotCare, &mut process).unwrap();
@@ -59,7 +68,9 @@ fn with_atom_with_encoding_atom_returns_name_in_binary() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -70,7 +81,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -82,7 +95,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0usize.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -94,7 +109,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -108,7 +125,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -120,7 +139,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -132,7 +153,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -144,7 +167,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
         &[0.into_process(&mut process), 1.into_process(&mut process)],
         &mut process,
@@ -159,7 +184,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -171,7 +198,9 @@ fn with_heap_binary_is_bad_argument() {
 
 #[test]
 fn with_subbinary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/atom_to_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/atom_to_list.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_without_encoding_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_name = "😈🤘";
     let atom_term = Term::str_to_atom(atom_name, Existence::DoNotCare, &mut process).unwrap();
 
@@ -18,7 +23,9 @@ fn with_atom_without_encoding_atom_returns_bad_argument() {
 
 #[test]
 fn with_atom_with_invalid_encoding_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_name = "😈🤘";
     let atom_term = Term::str_to_atom(atom_name, Existence::DoNotCare, &mut process).unwrap();
     let invalid_encoding_atom_term =
@@ -32,7 +39,9 @@ fn with_atom_with_invalid_encoding_atom_returns_bad_argument() {
 
 #[test]
 fn with_atom_with_encoding_atom_returns_chars_in_list() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_name = "😈🤘";
     let atom_term = Term::str_to_atom(atom_name, Existence::DoNotCare, &mut process).unwrap();
     let latin1_atom_term = Term::str_to_atom("latin1", Existence::DoNotCare, &mut process).unwrap();
@@ -83,7 +92,9 @@ fn with_atom_with_encoding_atom_returns_chars_in_list() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -94,7 +105,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -106,7 +119,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0usize.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -118,7 +133,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -132,7 +149,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -144,7 +163,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -156,7 +177,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -168,7 +191,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
         &[0.into_process(&mut process), 1.into_process(&mut process)],
         &mut process,
@@ -183,7 +208,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -195,7 +222,9 @@ fn with_heap_binary_is_bad_argument() {
 
 #[test]
 fn with_subbinary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/binary_byte_range_to_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_byte_range_to_list.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -22,7 +27,9 @@ fn with_atom_returns_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::binary_byte_range_to_list(
@@ -37,7 +44,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(
@@ -53,7 +62,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0usize.into_process(&mut process);
 
     assert_bad_argument!(
@@ -69,7 +80,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -87,7 +100,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -103,7 +118,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(
@@ -119,7 +136,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -135,7 +154,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(
@@ -151,7 +172,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_with_start_less_than_stop_returns_list_of_bytes() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0, 1, 2], &mut process);
 
     assert_eq_in_process!(
@@ -172,7 +195,9 @@ fn with_heap_binary_with_start_less_than_stop_returns_list_of_bytes() {
 
 #[test]
 fn with_heap_binary_with_start_equal_to_stop_returns_list_of_single_byte() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0, 1, 2], &mut process);
 
     assert_eq_in_process!(
@@ -193,7 +218,9 @@ fn with_heap_binary_with_start_equal_to_stop_returns_list_of_single_byte() {
 
 #[test]
 fn with_heap_binary_with_start_greater_than_stop_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0, 1, 2], &mut process);
 
     assert_bad_argument!(
@@ -209,7 +236,9 @@ fn with_heap_binary_with_start_greater_than_stop_returns_bad_argument() {
 
 #[test]
 fn with_subbinary_with_start_less_than_stop_returns_list_of_bytes() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, 0, 1, 2>>
     let binary_term = Term::slice_to_binary(&[128, 0, 129, 0b0000_0000], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 1, 3, 0, &mut process);
@@ -232,7 +261,9 @@ fn with_subbinary_with_start_less_than_stop_returns_list_of_bytes() {
 
 #[test]
 fn with_subbinary_with_start_equal_to_stop_returns_list_of_single_byte() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, 0, 1, 2>>
     let binary_term = Term::slice_to_binary(&[128, 0, 129, 0b0000_0000], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 1, 3, 0, &mut process);
@@ -255,7 +286,9 @@ fn with_subbinary_with_start_equal_to_stop_returns_list_of_single_byte() {
 
 #[test]
 fn with_subbinary_with_start_greater_than_stop_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, 0, 1, 2>>
     let binary_term = Term::slice_to_binary(&[128, 0, 129, 0b0000_0000], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 1, 3, 0, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/binary_in_base_to_integer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_in_base_to_integer.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("😈🤘", Existence::DoNotCare, &mut process).unwrap();
     let base_term: Term = 16.into_process(&mut process);
 
@@ -18,7 +23,9 @@ fn with_atom_returns_bad_argument() {
 
 #[test]
 fn with_empty_list_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let base_term: Term = 16.into_process(&mut process);
 
     assert_bad_argument!(
@@ -29,7 +36,9 @@ fn with_empty_list_returns_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
     let base_term: Term = 16.into_process(&mut process);
 
@@ -41,7 +50,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0usize.into_process(&mut process);
     let base_term: Term = 16.into_process(&mut process);
 
@@ -53,7 +64,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term: Term = <BigInt as Num>::from_str_radix("18446744073709551616", 10)
         .unwrap()
         .into_process(&mut process);
@@ -67,7 +80,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
     let base_term: Term = 16.into_process(&mut process);
 
@@ -79,7 +94,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let base_term: Term = 16.into_process(&mut process);
 
@@ -91,7 +108,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let base_term: Term = 16.into_process(&mut process);
 
@@ -103,7 +122,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
     let base_term: Term = 16.into_process(&mut process);
 
@@ -115,7 +136,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_with_min_small_integer_returns_small_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("-800000000000000".as_bytes(), &mut process);
     let base_term: Term = 16.into_process(&mut process);
 
@@ -134,7 +157,9 @@ fn with_heap_binary_with_min_small_integer_returns_small_integer() {
 
 #[test]
 fn with_heap_binary_with_max_small_integer_returns_small_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("7FFFFFFFFFFFFFF".as_bytes(), &mut process);
     let base_term: Term = 16.into_process(&mut process);
 
@@ -153,7 +178,9 @@ fn with_heap_binary_with_max_small_integer_returns_small_integer() {
 
 #[test]
 fn with_heap_binary_with_less_than_min_small_integer_returns_big_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("-800000000000001".as_bytes(), &mut process);
     let base_term: Term = 16.into_process(&mut process);
 
@@ -179,7 +206,9 @@ fn with_heap_binary_with_less_than_min_small_integer_returns_big_integer() {
 
 #[test]
 fn with_heap_binary_with_greater_than_max_small_integer_returns_big_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("800000000000000".as_bytes(), &mut process);
     let base_term: Term = 16.into_process(&mut process);
 
@@ -205,7 +234,9 @@ fn with_heap_binary_with_greater_than_max_small_integer_returns_big_integer() {
 
 #[test]
 fn with_subbinary_with_min_small_integer_returns_small_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, Integer.to_string(-576460752303423488, 16) :: binary>>
     let heap_binary_term = Term::slice_to_binary(
         &[
@@ -246,7 +277,9 @@ fn with_subbinary_with_min_small_integer_returns_small_integer() {
 
 #[test]
 fn with_subbinary_with_max_small_integer_returns_small_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, Integer.to_string(576460752303423487, 16) :: binary>>
     let heap_binary_term = Term::slice_to_binary(
         &[
@@ -286,7 +319,9 @@ fn with_subbinary_with_max_small_integer_returns_small_integer() {
 
 #[test]
 fn with_subbinary_with_less_than_min_small_integer_returns_big_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, Integer.to_string(-576460752303423489, 16) :: binary>>
     let heap_binary_term = Term::slice_to_binary(
         &[
@@ -336,7 +371,9 @@ fn with_subbinary_with_less_than_min_small_integer_returns_big_integer() {
 
 #[test]
 fn with_subbinary_with_greater_than_max_small_integer_returns_big_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, Integer.to_string(576460752303423488, 16) :: binary>>
     let heap_binary_term = Term::slice_to_binary(
         &[

--- a/lumen_runtime/src/otp/erlang/tests/binary_options_to_term.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_options_to_term.rs
@@ -1,11 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
+use crate::environment::{self, Environment};
+
 mod with_safe {
     use super::*;
 
     #[test]
     fn with_binary_encoding_atom_that_does_not_exist_returns_bad_argument() {
-        let mut process: Process = Default::default();
+        let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+        let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+        let mut process = process_rw_lock.write().unwrap();
         // :erlang.term_to_binary(:atom)
         let binary_term = Term::slice_to_binary(&[131, 100, 0, 4, 97, 116, 111, 109], &mut process);
         let options = Term::cons(
@@ -28,7 +34,9 @@ mod with_safe {
 
     #[test]
     fn with_binary_encoding_list_containing_atom_that_does_not_exist_returns_bad_argument() {
-        let mut process: Process = Default::default();
+        let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+        let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+        let mut process = process_rw_lock.write().unwrap();
         // :erlang.term_to_binary([:atom])
         let binary_term = Term::slice_to_binary(
             &[131, 108, 0, 0, 0, 1, 100, 0, 4, 97, 116, 111, 109, 106],
@@ -58,7 +66,9 @@ mod with_safe {
 
     #[test]
     fn with_binary_encoding_small_tuple_containing_atom_that_does_not_exist_returns_bad_argument() {
-        let mut process: Process = Default::default();
+        let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+        let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+        let mut process = process_rw_lock.write().unwrap();
         // :erlang.term_to_binary({:atom})
         let binary_term =
             Term::slice_to_binary(&[131, 104, 1, 100, 0, 4, 97, 116, 111, 109], &mut process);
@@ -85,7 +95,9 @@ mod with_safe {
 
     #[test]
     fn with_binary_encoding_small_atom_utf8_that_does_not_exist_returns_bad_argument() {
-        let mut process: Process = Default::default();
+        let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+        let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+        let mut process = process_rw_lock.write().unwrap();
         // :erlang.term_to_binary(:"😈")
         let binary_term = Term::slice_to_binary(&[131, 119, 4, 240, 159, 152, 136], &mut process);
         let options = Term::cons(
@@ -109,7 +121,9 @@ mod with_safe {
 
 #[test]
 fn with_used_with_binary_returns_how_many_bytes_were_consumed_along_with_term() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<131,100,0,5,"hello","world">>
     let binary_term = Term::slice_to_binary(
         &[

--- a/lumen_runtime/src/otp/erlang/tests/binary_part.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_part.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -22,7 +27,9 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::binary_part(
@@ -37,7 +44,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(
@@ -53,7 +62,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term: Term = 0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -69,7 +80,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term: Term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -87,7 +100,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term: Term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -103,7 +118,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(
@@ -119,7 +136,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -135,7 +154,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
         &[0.into_process(&mut process), 1.into_process(&mut process)],
         &mut process,
@@ -154,7 +175,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_without_integer_start_without_integer_length_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let start_term = Term::slice_to_tuple(
         &[0.into_process(&mut process), 0.into_process(&mut process)],
@@ -170,7 +193,9 @@ fn with_heap_binary_without_integer_start_without_integer_length_returns_bad_arg
 
 #[test]
 fn with_heap_binary_without_integer_start_with_integer_length_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let start_term = 0.into_process(&mut process);
     let length_term = Term::str_to_atom("all", Existence::DoNotCare, &mut process).unwrap();
@@ -183,7 +208,9 @@ fn with_heap_binary_without_integer_start_with_integer_length_returns_bad_argume
 
 #[test]
 fn with_heap_binary_with_integer_start_without_integer_length_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let start_term = 0.into_process(&mut process);
     let length_term = Term::str_to_atom("all", Existence::DoNotCare, &mut process).unwrap();
@@ -196,7 +223,9 @@ fn with_heap_binary_with_integer_start_without_integer_length_returns_bad_argume
 
 #[test]
 fn with_heap_binary_with_negative_start_with_valid_length_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let start_term = (-1isize).into_process(&mut process);
     let length_term = 0.into_process(&mut process);
@@ -209,7 +238,9 @@ fn with_heap_binary_with_negative_start_with_valid_length_returns_bad_argument()
 
 #[test]
 fn with_heap_binary_with_start_greater_than_size_with_non_negative_length_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let start_term = 1.into_process(&mut process);
     let length_term = 0.into_process(&mut process);
@@ -223,7 +254,9 @@ fn with_heap_binary_with_start_greater_than_size_with_non_negative_length_return
 #[test]
 fn with_heap_binary_with_start_less_than_size_with_negative_length_past_start_returns_bad_argument()
 {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0], &mut process);
     let start_term = 0.into_process(&mut process);
     let length_term = (-1isize).into_process(&mut process);
@@ -236,7 +269,9 @@ fn with_heap_binary_with_start_less_than_size_with_negative_length_past_start_re
 
 #[test]
 fn with_heap_binary_with_start_less_than_size_with_positive_length_past_end_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0], &mut process);
     let start_term = 0.into_process(&mut process);
     let length_term = 2.into_process(&mut process);
@@ -249,7 +284,9 @@ fn with_heap_binary_with_start_less_than_size_with_positive_length_past_end_retu
 
 #[test]
 fn with_heap_binary_with_zero_start_and_size_length_returns_binary() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0], &mut process);
     let start_term = 0.into_process(&mut process);
     let length_term = 1.into_process(&mut process);
@@ -268,7 +305,9 @@ fn with_heap_binary_with_zero_start_and_size_length_returns_binary() {
 
 #[test]
 fn with_heap_binary_with_size_start_and_negative_size_length_returns_binary() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0], &mut process);
     let start_term = 1.into_process(&mut process);
     let length_term = (-1isize).into_process(&mut process);
@@ -287,7 +326,9 @@ fn with_heap_binary_with_size_start_and_negative_size_length_returns_binary() {
 
 #[test]
 fn with_heap_binary_with_positive_start_and_negative_length_returns_subbinary() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0, 1], &mut process);
     let start_term = 1.into_process(&mut process);
     let length_term = (-1isize).into_process(&mut process);
@@ -310,7 +351,9 @@ fn with_heap_binary_with_positive_start_and_negative_length_returns_subbinary() 
 
 #[test]
 fn with_heap_binary_with_positive_start_and_positive_length_returns_subbinary() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0, 1], &mut process);
     let start_term = 1.into_process(&mut process);
     let length_term = 1.into_process(&mut process);
@@ -333,7 +376,9 @@ fn with_heap_binary_with_positive_start_and_positive_length_returns_subbinary() 
 
 #[test]
 fn with_subbinary_without_integer_start_without_integer_length_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
@@ -351,7 +396,9 @@ fn with_subbinary_without_integer_start_without_integer_length_returns_bad_argum
 
 #[test]
 fn with_subbinary_without_integer_start_with_integer_length_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
@@ -366,7 +413,9 @@ fn with_subbinary_without_integer_start_with_integer_length_returns_bad_argument
 
 #[test]
 fn with_subbinary_with_integer_start_without_integer_length_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
@@ -381,7 +430,9 @@ fn with_subbinary_with_integer_start_without_integer_length_returns_bad_argument
 
 #[test]
 fn with_subbinary_with_negative_start_with_valid_length_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
@@ -396,7 +447,9 @@ fn with_subbinary_with_negative_start_with_valid_length_returns_bad_argument() {
 
 #[test]
 fn with_subbinary_with_start_greater_than_size_with_non_negative_length_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 0, 1, &mut process);
@@ -411,7 +464,9 @@ fn with_subbinary_with_start_greater_than_size_with_non_negative_length_returns_
 
 #[test]
 fn with_subbinary_with_start_less_than_size_with_negative_length_past_start_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
@@ -426,7 +481,9 @@ fn with_subbinary_with_start_less_than_size_with_negative_length_past_start_retu
 
 #[test]
 fn with_subbinary_with_start_less_than_size_with_positive_length_past_end_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 1, 1, &mut process);
@@ -441,7 +498,9 @@ fn with_subbinary_with_start_less_than_size_with_positive_length_past_end_return
 
 #[test]
 fn with_subbinary_with_zero_start_and_byte_count_length_returns_new_subbinary_with_bytes() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
@@ -458,7 +517,9 @@ fn with_subbinary_with_zero_start_and_byte_count_length_returns_new_subbinary_wi
 #[test]
 fn with_subbinary_with_byte_count_start_and_negative_byte_count_length_returns_new_subbinary_with_bytes(
 ) {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
@@ -474,7 +535,9 @@ fn with_subbinary_with_byte_count_start_and_negative_byte_count_length_returns_n
 
 #[test]
 fn with_subbinary_with_positive_start_and_negative_length_returns_subbinary() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term = Term::slice_to_binary(&[0b0000_00001, 0b1111_1110], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 1, 0, &mut process);
     let start_term = 1.into_process(&mut process);
@@ -498,7 +561,9 @@ fn with_subbinary_with_positive_start_and_negative_length_returns_subbinary() {
 
 #[test]
 fn with_subbinary_with_positive_start_and_positive_length_returns_subbinary() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term: Term = process.subbinary(binary_term, 0, 7, 2, 1).into();

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_atom.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_atom.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -18,7 +23,9 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -29,7 +36,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -41,7 +50,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0usize.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -53,7 +64,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -67,7 +80,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -79,7 +94,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -91,7 +108,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -103,7 +122,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
         &[0.into_process(&mut process), 1.into_process(&mut process)],
         &mut process,
@@ -118,7 +139,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_without_encoding_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
     assert_bad_argument!(
@@ -129,7 +152,9 @@ fn with_heap_binary_without_encoding_atom_returns_bad_argument() {
 
 #[test]
 fn with_heap_binary_with_invalid_encoding_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let invalid_encoding_term =
         Term::str_to_atom("invalid_encoding", Existence::DoNotCare, &mut process).unwrap();
@@ -142,7 +167,9 @@ fn with_heap_binary_with_invalid_encoding_atom_returns_bad_argument() {
 
 #[test]
 fn with_heap_binary_with_valid_encoding_returns_atom() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("😈".as_bytes(), &mut process);
     let latin1_atom_term = Term::str_to_atom("latin1", Existence::DoNotCare, &mut process).unwrap();
     let unicode_atom_term =
@@ -169,7 +196,9 @@ fn with_heap_binary_with_valid_encoding_returns_atom() {
 
 #[test]
 fn with_subbinary_with_bit_count_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
@@ -184,7 +213,9 @@ fn with_subbinary_with_bit_count_returns_bad_argument() {
 
 #[test]
 fn with_subbinary_without_bit_count_returns_atom_with_bytes() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term = Term::slice_to_binary("😈🤘".as_bytes(), &mut process);
     let subbinary_term = Term::subbinary(binary_term, 4, 0, 4, 0, &mut process);
     let unicode_atom_term =

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_existing_atom.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_existing_atom.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -18,7 +23,9 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -29,7 +36,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -41,7 +50,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0usize.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -53,7 +64,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -67,7 +80,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
     let encoding_term = Term::str_to_atom("unicode", Existence::DoNotCare, &mut process).unwrap();
 
@@ -79,7 +94,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
         &[0.into_process(&mut process), 1.into_process(&mut process)],
         &mut process,
@@ -94,7 +111,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_without_encoding_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
     assert_bad_argument!(
@@ -109,7 +128,9 @@ fn with_heap_binary_without_encoding_atom_returns_bad_argument() {
 
 #[test]
 fn with_heap_binary_with_invalid_encoding_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let invalid_encoding_term =
         Term::str_to_atom("invalid_encoding", Existence::DoNotCare, &mut process).unwrap();
@@ -122,7 +143,9 @@ fn with_heap_binary_with_invalid_encoding_atom_returns_bad_argument() {
 
 #[test]
 fn with_heap_binary_with_valid_encoding_without_existing_atom_returns_atom() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("😈".as_bytes(), &mut process);
     let latin1_atom_term = Term::str_to_atom("latin1", Existence::DoNotCare, &mut process).unwrap();
     let unicode_atom_term =
@@ -145,7 +168,9 @@ fn with_heap_binary_with_valid_encoding_without_existing_atom_returns_atom() {
 
 #[test]
 fn with_heap_binary_with_valid_encoding_with_existing_atom_returns_atom() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("😈".as_bytes(), &mut process);
     let latin1_atom_term = Term::str_to_atom("latin1", Existence::DoNotCare, &mut process).unwrap();
     let unicode_atom_term =
@@ -172,7 +197,9 @@ fn with_heap_binary_with_valid_encoding_with_existing_atom_returns_atom() {
 
 #[test]
 fn with_subbinary_with_bit_count_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
@@ -187,7 +214,9 @@ fn with_subbinary_with_bit_count_returns_bad_argument() {
 
 #[test]
 fn with_subbinary_without_bit_count_without_existing_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term = Term::slice_to_binary("😈🤘".as_bytes(), &mut process);
     let subbinary_term = Term::subbinary(binary_term, 4, 0, 4, 0, &mut process);
     let unicode_atom_term =
@@ -201,7 +230,9 @@ fn with_subbinary_without_bit_count_without_existing_atom_returns_bad_argument()
 
 #[test]
 fn with_subbinary_without_bit_count_with_existing_atom_returns_atom_with_bytes() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term = Term::slice_to_binary("😈🤘".as_bytes(), &mut process);
     let subbinary_term = Term::subbinary(binary_term, 4, 0, 4, 0, &mut process);
     let unicode_atom_term =

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_float.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_float.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("😈🤘", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::binary_to_float(atom_term, &mut process), process);
@@ -14,7 +19,9 @@ fn with_atom_returns_bad_argument() {
 
 #[test]
 fn with_empty_list_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::binary_to_float(Term::EMPTY_LIST, &mut process),
@@ -24,7 +31,9 @@ fn with_empty_list_returns_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(erlang::binary_to_float(list_term, &mut process), process);
@@ -32,7 +41,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0usize.into_process(&mut process);
 
     assert_bad_argument!(
@@ -43,7 +54,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term: Term = <BigInt as Num>::from_str_radix("18446744073709551616", 10)
         .unwrap()
         .into_process(&mut process);
@@ -56,7 +69,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(erlang::binary_to_float(float_term, &mut process), process);
@@ -64,7 +79,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(
@@ -75,7 +92,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -86,7 +105,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::binary_to_float(tuple_term, &mut process), process);
@@ -94,7 +115,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_with_integer_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("1".as_bytes(), &mut process);
 
     assert_bad_argument!(
@@ -105,7 +128,9 @@ fn with_heap_binary_with_integer_returns_bad_argument() {
 
 #[test]
 fn with_heap_binary_with_min_f64_returns_float() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term =
             Term::slice_to_binary("-179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0".as_bytes(), &mut process);
 
@@ -118,7 +143,9 @@ fn with_heap_binary_with_min_f64_returns_float() {
 
 #[test]
 fn with_heap_binary_with_max_f64_returns_float() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term =
             Term::slice_to_binary("179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0".as_bytes(), &mut process);
 
@@ -131,7 +158,9 @@ fn with_heap_binary_with_max_f64_returns_float() {
 
 #[test]
 fn with_heap_binary_with_less_than_min_f64_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term =
             Term::slice_to_binary("-1797693134862315700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0".as_bytes(), &mut process);
 
@@ -143,7 +172,9 @@ fn with_heap_binary_with_less_than_min_f64_returns_bad_argument() {
 
 #[test]
 fn with_heap_binary_with_greater_than_max_f64_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term =
             Term::slice_to_binary("17976931348623157000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0".as_bytes(), &mut process);
 
@@ -155,7 +186,9 @@ fn with_heap_binary_with_greater_than_max_f64_returns_bad_argument() {
 
 #[test]
 fn with_subbinary_with_min_f64_returns_float() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, "-179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0">>
     let heap_binary_term = Term::slice_to_binary(
         &[
@@ -486,7 +519,9 @@ fn with_subbinary_with_min_f64_returns_float() {
 
 #[test]
 fn with_subbinary_with_max_f64_returns_float() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, "179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0">>
     let heap_binary_term = Term::slice_to_binary(
         &[
@@ -816,7 +851,9 @@ fn with_subbinary_with_max_f64_returns_float() {
 
 #[test]
 fn with_subbinary_with_less_than_min_f64_returns_bag_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, "-1797693134862315700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0">>
     let heap_binary_term = Term::slice_to_binary(
         &[
@@ -1147,7 +1184,9 @@ fn with_subbinary_with_less_than_min_f64_returns_bag_argument() {
 
 #[test]
 fn with_subbinary_with_greater_than_max_f64_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, "576460752303423488">>
     let heap_binary_term = Term::slice_to_binary(
         &[

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_integer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_integer.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("😈🤘", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::binary_to_integer(atom_term, &mut process), process);
@@ -14,7 +19,9 @@ fn with_atom_returns_bad_argument() {
 
 #[test]
 fn with_empty_list_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::binary_to_integer(Term::EMPTY_LIST, &mut process),
@@ -24,7 +31,9 @@ fn with_empty_list_returns_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(erlang::binary_to_integer(list_term, &mut process), process);
@@ -32,7 +41,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0usize.into_process(&mut process);
 
     assert_bad_argument!(
@@ -43,7 +54,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term: Term = <BigInt as Num>::from_str_radix("18446744073709551616", 10)
         .unwrap()
         .into_process(&mut process);
@@ -56,7 +69,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(erlang::binary_to_integer(float_term, &mut process), process);
@@ -64,7 +79,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::binary_to_integer(tuple_term, &mut process), process);
@@ -72,7 +89,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_with_min_small_integer_returns_small_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("-576460752303423488".as_bytes(), &mut process);
 
     let integer_result = erlang::binary_to_integer(heap_binary_term, &mut process);
@@ -89,7 +108,9 @@ fn with_heap_binary_with_min_small_integer_returns_small_integer() {
 
 #[test]
 fn with_heap_binary_with_max_small_integer_returns_small_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("576460752303423487".as_bytes(), &mut process);
 
     let integer_result = erlang::binary_to_integer(heap_binary_term, &mut process);
@@ -106,7 +127,9 @@ fn with_heap_binary_with_max_small_integer_returns_small_integer() {
 
 #[test]
 fn with_heap_binary_with_less_than_min_small_integer_returns_big_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("-576460752303423489".as_bytes(), &mut process);
 
     let integer_result = erlang::binary_to_integer(heap_binary_term, &mut process);
@@ -130,7 +153,9 @@ fn with_heap_binary_with_less_than_min_small_integer_returns_big_integer() {
 
 #[test]
 fn with_heap_binary_with_greater_than_max_small_integer_returns_big_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("576460752303423488".as_bytes(), &mut process);
 
     let integer_result = erlang::binary_to_integer(heap_binary_term, &mut process);
@@ -154,7 +179,9 @@ fn with_heap_binary_with_greater_than_max_small_integer_returns_big_integer() {
 
 #[test]
 fn with_heap_binary_with_non_decimal_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary("FF".as_bytes(), &mut process);
 
     assert_bad_argument!(
@@ -165,7 +192,9 @@ fn with_heap_binary_with_non_decimal_returns_bad_argument() {
 
 #[test]
 fn with_subbinary_with_min_small_integer_returns_small_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, "-576460752303423488">>
     let heap_binary_term = Term::slice_to_binary(
         &[
@@ -208,7 +237,9 @@ fn with_subbinary_with_min_small_integer_returns_small_integer() {
 
 #[test]
 fn with_subbinary_with_max_small_integer_returns_small_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, "576460752303423487">>
     let heap_binary_term = Term::slice_to_binary(
         &[
@@ -250,7 +281,9 @@ fn with_subbinary_with_max_small_integer_returns_small_integer() {
 
 #[test]
 fn with_subbinary_with_less_than_min_small_integer_returns_big_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, "-576460752303423489">>
     let heap_binary_term = Term::slice_to_binary(
         &[
@@ -300,7 +333,9 @@ fn with_subbinary_with_less_than_min_small_integer_returns_big_integer() {
 
 #[test]
 fn with_subbinary_with_greater_than_max_small_integer_returns_big_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, "576460752303423488">>
     let heap_binary_term = Term::slice_to_binary(
         &[
@@ -349,7 +384,9 @@ fn with_subbinary_with_greater_than_max_small_integer_returns_big_integer() {
 
 #[test]
 fn with_subbinary_with_non_decimal_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1:1, "FF>>
     let heap_binary_term = Term::slice_to_binary(&[163, 35, 0b000_0000], &mut process);
     let subbinary_term = Term::subbinary(heap_binary_term, 0, 1, 2, 0, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_list.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::binary_to_list(atom_term, &mut process), process);
@@ -14,7 +19,9 @@ fn with_atom_returns_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::binary_to_list(Term::EMPTY_LIST, &mut process),
@@ -24,7 +31,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(erlang::binary_to_list(list_term, &mut process), process);
@@ -32,7 +41,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0usize.into_process(&mut process);
 
     assert_bad_argument!(
@@ -43,7 +54,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -56,7 +69,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(erlang::binary_to_list(float_term, &mut process), process);
@@ -64,7 +79,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(
@@ -75,7 +92,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -86,7 +105,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::binary_to_list(tuple_term, &mut process), process);
@@ -94,7 +115,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_returns_list_of_bytes() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0, 1, 2], &mut process);
 
     assert_eq_in_process!(
@@ -114,7 +137,9 @@ fn with_heap_binary_returns_list_of_bytes() {
 
 #[test]
 fn with_subbinary_without_bit_count_returns_list_of_bytes() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, 0, 1, 2>>
     let binary_term = Term::slice_to_binary(&[128, 0, 129, 0b0000_0000], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 1, 3, 0, &mut process);
@@ -136,7 +161,9 @@ fn with_subbinary_without_bit_count_returns_list_of_bytes() {
 
 #[test]
 fn with_subbinary_with_bit_count_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, 0, 1, 2>>
     let binary_term = Term::slice_to_binary(&[128, 0, 129, 0b0000_0000], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 0, 3, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_term.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_term.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::binary_to_term(atom_term, &mut process), process);
@@ -14,7 +19,9 @@ fn with_atom_returns_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::binary_to_term(Term::EMPTY_LIST, &mut process),
@@ -24,7 +31,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(erlang::binary_to_term(list_term, &mut process), process);
@@ -32,7 +41,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0usize.into_process(&mut process);
 
     assert_bad_argument!(
@@ -43,7 +54,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -56,7 +69,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(erlang::binary_to_term(float_term, &mut process), process);
@@ -64,7 +79,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(
@@ -75,7 +92,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -86,7 +105,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::binary_to_term(tuple_term, &mut process), process);
@@ -94,7 +115,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_encoding_atom_returns_atom() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // :erlang.term_to_binary(:atom)
     let heap_binary_term =
         Term::slice_to_binary(&[131, 100, 0, 4, 97, 116, 111, 109], &mut process);
@@ -108,7 +131,9 @@ fn with_heap_binary_encoding_atom_returns_atom() {
 
 #[test]
 fn with_heap_binary_encoding_empty_list_returns_empty_list() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // :erlang.term_to_binary([])
     let heap_binary_term = Term::slice_to_binary(&[131, 106], &mut process);
 
@@ -121,7 +146,9 @@ fn with_heap_binary_encoding_empty_list_returns_empty_list() {
 
 #[test]
 fn with_heap_binary_encoding_list_returns_list() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // :erlang.term_to_binary([:zero, 1])
     let heap_binary_term = Term::slice_to_binary(
         &[
@@ -143,7 +170,9 @@ fn with_heap_binary_encoding_list_returns_list() {
 
 #[test]
 fn with_heap_binary_encoding_small_integer_returns_small_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // :erlang.term_to_binary(0)
     let heap_binary_term = Term::slice_to_binary(&[131, 97, 0], &mut process);
 
@@ -156,7 +185,9 @@ fn with_heap_binary_encoding_small_integer_returns_small_integer() {
 
 #[test]
 fn with_heap_binary_encoding_integer_returns_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // :erlang.term_to_binary(-2147483648)
     let heap_binary_term = Term::slice_to_binary(&[131, 98, 128, 0, 0, 0], &mut process);
 
@@ -169,7 +200,9 @@ fn with_heap_binary_encoding_integer_returns_integer() {
 
 #[test]
 fn with_heap_binary_encoding_new_float_returns_float() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // :erlang.term_to_binary(1.0)
     let heap_binary_term =
         Term::slice_to_binary(&[131, 70, 63, 240, 0, 0, 0, 0, 0, 0], &mut process);
@@ -183,7 +216,9 @@ fn with_heap_binary_encoding_new_float_returns_float() {
 
 #[test]
 fn with_heap_binary_encoding_small_tuple_returns_tuple() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // :erlang.term_to_binary({:zero, 1})
     let heap_binary_term = Term::slice_to_binary(
         &[131, 104, 2, 100, 0, 4, 122, 101, 114, 111, 97, 1],
@@ -205,7 +240,9 @@ fn with_heap_binary_encoding_small_tuple_returns_tuple() {
 
 #[test]
 fn with_heap_binary_encoding_byte_list_returns_list() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // :erlang.term_to_binary([?0, ?1])
     let heap_binary_term = Term::slice_to_binary(&[131, 107, 0, 2, 48, 49], &mut process);
 
@@ -226,7 +263,9 @@ fn with_heap_binary_encoding_byte_list_returns_list() {
 
 #[test]
 fn with_heap_binary_encoding_binary_returns_binary() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // :erlang.term_to_binary(<<0, 1>>)
     let heap_binary_term = Term::slice_to_binary(&[131, 109, 0, 0, 0, 2, 0, 1], &mut process);
 
@@ -239,7 +278,9 @@ fn with_heap_binary_encoding_binary_returns_binary() {
 
 #[test]
 fn with_heap_binary_encoding_small_big_integer_returns_big_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // :erlang.term_to_binary(4294967295)
     let heap_binary_term =
         Term::slice_to_binary(&[131, 110, 4, 0, 255, 255, 255, 255], &mut process);
@@ -253,7 +294,9 @@ fn with_heap_binary_encoding_small_big_integer_returns_big_integer() {
 
 #[test]
 fn with_heap_binary_encoding_bit_string_returns_subbinary() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // :erlang.term_to_binary(<<1, 2::3>>)
     let heap_binary_term = Term::slice_to_binary(&[131, 77, 0, 0, 0, 2, 3, 1, 64], &mut process);
 
@@ -273,7 +316,9 @@ fn with_heap_binary_encoding_bit_string_returns_subbinary() {
 
 #[test]
 fn with_heap_binary_encoding_small_atom_utf8_returns_atom() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // :erlang.term_to_binary(:"😈")
     let heap_binary_term = Term::slice_to_binary(&[131, 119, 4, 240, 159, 152, 136], &mut process);
 
@@ -286,7 +331,9 @@ fn with_heap_binary_encoding_small_atom_utf8_returns_atom() {
 
 #[test]
 fn with_subbinary_encoding_atom_returns_atom() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, :erlang.term_to_binary(:atom) :: binary>>
     let original_term = Term::slice_to_binary(
         &[193, 178, 0, 2, 48, 186, 55, 182, 0b1000_0000],
@@ -303,7 +350,9 @@ fn with_subbinary_encoding_atom_returns_atom() {
 
 #[test]
 fn with_subbinary_encoding_empty_list_returns_empty_list() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, :erlang.term_to_binary([]) :: binary>>
     let original_term = Term::slice_to_binary(&[193, 181, 0b0000_0000], &mut process);
     let subbinary_term = Term::subbinary(original_term, 0, 1, 2, 0, &mut process);
@@ -317,7 +366,9 @@ fn with_subbinary_encoding_empty_list_returns_empty_list() {
 
 #[test]
 fn with_subbinary_encoding_list_returns_list() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, :erlang.term_to_binary([:zero, 1]) :: binary>>
     let original_term = Term::slice_to_binary(
         &[
@@ -340,7 +391,9 @@ fn with_subbinary_encoding_list_returns_list() {
 
 #[test]
 fn with_subbinary_encoding_small_integer_returns_small_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, :erlang.term_to_binary(0) :: binary>>
     let original_term = Term::slice_to_binary(&[193, 176, 128, 0], &mut process);
     let subbinary_term = Term::subbinary(original_term, 0, 1, 3, 0, &mut process);
@@ -354,7 +407,9 @@ fn with_subbinary_encoding_small_integer_returns_small_integer() {
 
 #[test]
 fn with_subbinary_encoding_integer_returns_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, :erlang.term_to_binary(-2147483648) :: binary>>
     let original_term = Term::slice_to_binary(&[193, 177, 64, 0, 0, 0, 0], &mut process);
     let subbinary_term = Term::subbinary(original_term, 0, 1, 6, 0, &mut process);
@@ -368,7 +423,9 @@ fn with_subbinary_encoding_integer_returns_integer() {
 
 #[test]
 fn with_subbinary_encoding_new_float_returns_float() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, :erlang.term_to_binary(1.0) :: binary>>
     let original_term =
         Term::slice_to_binary(&[193, 163, 31, 248, 0, 0, 0, 0, 0, 0, 0], &mut process);
@@ -383,7 +440,9 @@ fn with_subbinary_encoding_new_float_returns_float() {
 
 #[test]
 fn with_subbinary_encoding_small_tuple_returns_tuple() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, :erlang.term_to_binary({:zero, 1}) :: binary>>
     let original_term = Term::slice_to_binary(
         &[
@@ -420,7 +479,9 @@ fn with_subbinary_encoding_small_tuple_returns_tuple() {
 
 #[test]
 fn with_subbinary_encoding_byte_list_returns_list() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, :erlang.term_to_binary([?0, ?1]) :: binary>>
     let original_term =
         Term::slice_to_binary(&[193, 181, 128, 1, 24, 24, 0b1000_0000], &mut process);
@@ -443,7 +504,9 @@ fn with_subbinary_encoding_byte_list_returns_list() {
 
 #[test]
 fn with_subbinary_encoding_binary_returns_binary() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, :erlang.term_to_binary(<<0, 1>>) :: binary>>
     let original_term =
         Term::slice_to_binary(&[193, 182, 128, 0, 0, 1, 0, 0, 0b1000_0000], &mut process);
@@ -458,7 +521,9 @@ fn with_subbinary_encoding_binary_returns_binary() {
 
 #[test]
 fn with_subbinary_encoding_small_big_integer_returns_big_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, :erlang.term_to_binary(4294967295) :: binary>>
     let original_term = Term::slice_to_binary(
         &[193, 183, 2, 0, 127, 255, 255, 255, 0b1000_0000],
@@ -475,7 +540,9 @@ fn with_subbinary_encoding_small_big_integer_returns_big_integer() {
 
 #[test]
 fn with_subbinary_encoding_bit_string_returns_subbinary() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, :erlang.term_to_binary(<<1, 2::3>>) :: binary>>
     let original_term =
         Term::slice_to_binary(&[193, 166, 128, 0, 0, 1, 1, 128, 160, 0], &mut process);
@@ -497,7 +564,9 @@ fn with_subbinary_encoding_bit_string_returns_subbinary() {
 
 #[test]
 fn with_subbinary_encoding_small_atom_utf8_returns_atom() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     // <<1::1, :erlang.term_to_binary(:"😈") :: binary>>
     let original_term = Term::slice_to_binary(&[193, 187, 130, 120, 79, 204, 68, 0], &mut process);
     let subbinary_term = Term::subbinary(original_term, 0, 1, 7, 0, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/bit_size.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bit_size.rs
@@ -1,10 +1,16 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
+
+use crate::environment::{self, Environment};
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::bit_size(atom_term, &mut process), process);
@@ -12,14 +18,18 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(erlang::bit_size(Term::EMPTY_LIST, &mut process), process);
 }
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(erlang::bit_size(list_term, &mut process), process);
@@ -27,7 +37,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term: Term = 0.into_process(&mut process);
 
     assert_bad_argument!(erlang::bit_size(small_integer_term, &mut process), process);
@@ -35,7 +47,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term: Term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -45,7 +59,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(erlang::bit_size(float_term, &mut process), process);
@@ -53,7 +69,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(erlang::bit_size(local_pid_term, &mut process), process);
@@ -61,7 +79,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(erlang::bit_size(external_pid_term, &mut process), process);
@@ -69,7 +89,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::bit_size(tuple_term, &mut process), process);
@@ -77,7 +99,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_is_eight_times_byte_count() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[1], &mut process);
 
     assert_eq_in_process!(
@@ -89,7 +113,9 @@ fn with_heap_binary_is_eight_times_byte_count() {
 
 #[test]
 fn with_subbinary_is_eight_times_byte_count_plus_bit_count() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term = Term::slice_to_binary(&[0, 1, 0b010], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 0, 2, 3, &mut process);
 

--- a/lumen_runtime/src/otp/erlang/tests/bitstring_to_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bitstring_to_list.rs
@@ -1,10 +1,16 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
+
+use crate::environment::{self, Environment};
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::bitstring_to_list(atom_term, &mut process), process);
@@ -12,7 +18,9 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::bitstring_to_list(Term::EMPTY_LIST, &mut process),
@@ -22,7 +30,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(erlang::bitstring_to_list(list_term, &mut process), process);
@@ -30,7 +40,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term: Term = 0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -41,7 +53,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term: Term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -54,7 +68,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(erlang::bitstring_to_list(float_term, &mut process), process);
@@ -62,7 +78,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(
@@ -73,7 +91,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -84,7 +104,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::bitstring_to_list(tuple_term, &mut process), process);
@@ -92,7 +114,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_returns_list_of_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0], &mut process);
 
     assert_eq_in_process!(
@@ -108,7 +132,9 @@ fn with_heap_binary_returns_list_of_integer() {
 
 #[test]
 fn with_subbinary_without_bit_count_returns_list_of_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term = Term::slice_to_binary(&[0, 1, 0b010], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 1, 0, 1, 0, &mut process);
 
@@ -125,7 +151,9 @@ fn with_subbinary_without_bit_count_returns_list_of_integer() {
 
 #[test]
 fn with_subbinary_with_bit_count_returns_list_of_integer_with_bitstring_for_bit_count() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term = Term::slice_to_binary(&[0, 1, 0b010], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 0, 2, 3, &mut process);
 

--- a/lumen_runtime/src/otp/erlang/tests/byte_size.rs
+++ b/lumen_runtime/src/otp/erlang/tests/byte_size.rs
@@ -1,10 +1,16 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
+
+use crate::environment::{self, Environment};
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::byte_size(atom_term, &mut process), process);
@@ -12,14 +18,18 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(erlang::byte_size(Term::EMPTY_LIST, &mut process), process);
 }
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(erlang::byte_size(list_term, &mut process), process);
@@ -27,7 +37,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term: Term = 0.into_process(&mut process);
 
     assert_bad_argument!(erlang::byte_size(small_integer_term, &mut process), process);
@@ -35,7 +47,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term: Term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -45,7 +59,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(erlang::byte_size(float_term, &mut process), process);
@@ -53,7 +69,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(erlang::byte_size(local_pid_term, &mut process), process);
@@ -61,7 +79,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(erlang::byte_size(external_pid_term, &mut process), process);
@@ -69,7 +89,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::byte_size(tuple_term, &mut process), process);
@@ -77,7 +99,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_is_byte_count() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[1], &mut process);
 
     assert_eq_in_process!(
@@ -89,7 +113,9 @@ fn with_heap_binary_is_byte_count() {
 
 #[test]
 fn with_subbinary_without_bit_count_is_byte_count() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term = Term::slice_to_binary(&[0, 1], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 1, 0, 1, 0, &mut process);
 
@@ -102,7 +128,9 @@ fn with_subbinary_without_bit_count_is_byte_count() {
 
 #[test]
 fn with_subbinary_with_bit_count_is_byte_count_plus_one() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term = Term::slice_to_binary(&[0, 1, 0b0100_0000], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 1, 0, 1, 3, &mut process);
 

--- a/lumen_runtime/src/otp/erlang/tests/ceil.rs
+++ b/lumen_runtime/src/otp/erlang/tests/ceil.rs
@@ -1,10 +1,16 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
+
+use crate::environment::{self, Environment};
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::ceil(atom_term, &mut process), process);
@@ -12,14 +18,18 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(erlang::ceil(Term::EMPTY_LIST, &mut process), process);
 }
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(erlang::ceil(list_term, &mut process), process);
@@ -27,7 +37,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_returns_same() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term: Term = 0.into_process(&mut process);
 
     let result = erlang::ceil(small_integer_term, &mut process);
@@ -38,7 +50,9 @@ fn with_small_integer_returns_same() {
 
 #[test]
 fn with_big_integer_returns_same() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term: Term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -51,7 +65,9 @@ fn with_big_integer_returns_same() {
 
 #[test]
 fn with_float_without_fraction_returns_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_eq_in_process!(
@@ -63,7 +79,9 @@ fn with_float_without_fraction_returns_integer() {
 
 #[test]
 fn with_float_with_fraction_rounds_up_to_next_integer() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = (-1.1).into_process(&mut process);
 
     let result = erlang::ceil(float_term, &mut process);
@@ -73,7 +91,9 @@ fn with_float_with_fraction_rounds_up_to_next_integer() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(erlang::ceil(local_pid_term, &mut process), process);
@@ -81,7 +101,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(erlang::ceil(external_pid_term, &mut process), process);
@@ -89,7 +111,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::ceil(tuple_term, &mut process), process);
@@ -97,7 +121,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[1], &mut process);
 
     assert_bad_argument!(erlang::ceil(heap_binary_term, &mut process), process);
@@ -105,7 +131,9 @@ fn with_heap_binary_is_bad_argument() {
 
 #[test]
 fn with_subbinary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term = Term::slice_to_binary(&[0, 1], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 1, 0, 1, 0, &mut process);
 

--- a/lumen_runtime/src/otp/erlang/tests/convert_time_unit.rs
+++ b/lumen_runtime/src/otp/erlang/tests/convert_time_unit.rs
@@ -1,8 +1,14 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
+use crate::environment::{self, Environment};
+
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
@@ -15,7 +21,9 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
 
@@ -27,7 +35,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
@@ -45,7 +55,9 @@ mod with_small_integer {
 
     #[test]
     fn without_valid_units_returns_bad_argument() {
-        let mut process: Process = Default::default();
+        let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+        let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+        let mut process = process_rw_lock.write().unwrap();
         let small_integer_term: Term = 0.into_process(&mut process);
         let valid_unit_term =
             Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
@@ -74,7 +86,9 @@ mod with_small_integer {
 
     #[test]
     fn with_valid_units_returns_converted_value() {
-        let mut process: Process = Default::default();
+        let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+        let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+        let mut process = process_rw_lock.write().unwrap();
         let small_integer_term: Term = 1_000_000_000.into_process(&mut process);
 
         assert_eq!(small_integer_term.tag(), Tag::SmallInteger);
@@ -676,7 +690,9 @@ mod with_big_integer {
 
     #[test]
     fn without_valid_units_returns_bad_argument() {
-        let mut process: Process = Default::default();
+        let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+        let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+        let mut process = process_rw_lock.write().unwrap();
         let big_integer_term: Term =
             <BigInt as Num>::from_str_radix("1_000_000_000_000_000_000", 10)
                 .unwrap()
@@ -711,7 +727,9 @@ mod with_big_integer {
 
     #[test]
     fn with_valid_units_returns_converted_value() {
-        let mut process: Process = Default::default();
+        let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+        let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+        let mut process = process_rw_lock.write().unwrap();
         let big_integer_term: Term =
             <BigInt as Num>::from_str_radix("1_000_000_000_000_000_000", 10)
                 .unwrap()
@@ -1435,7 +1453,9 @@ mod with_big_integer {
 
 #[test]
 fn with_float_returns_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
@@ -1448,7 +1468,9 @@ fn with_float_returns_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
@@ -1461,7 +1483,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
@@ -1479,7 +1503,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
@@ -1492,7 +1518,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[1], &mut process);
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
     let to_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();
@@ -1505,7 +1533,9 @@ fn with_heap_binary_is_bad_argument() {
 
 #[test]
 fn with_subbinary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term = Term::slice_to_binary(&[0, 1], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 1, 0, 1, 0, &mut process);
     let from_unit_term = Term::str_to_atom("native", Existence::DoNotCare, &mut process).unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/delete_element.rs
+++ b/lumen_runtime/src/otp/erlang/tests/delete_element.rs
@@ -1,10 +1,16 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
+
+use crate::environment::{self, Environment};
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -15,7 +21,9 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::delete_element(Term::EMPTY_LIST, 0.into_process(&mut process), &mut process),
@@ -25,7 +33,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(
@@ -36,7 +46,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term: Term = 0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -51,7 +63,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term: Term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -64,7 +78,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -75,7 +91,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(
@@ -86,7 +104,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -101,7 +121,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_without_small_integer_index_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
         &[
             0.into_process(&mut process),
@@ -134,7 +156,9 @@ fn with_tuple_without_small_integer_index_is_bad_argument() {
 
 #[test]
 fn with_tuple_without_index_in_range_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let empty_tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(
@@ -145,7 +169,9 @@ fn with_tuple_without_index_in_range_is_bad_argument() {
 
 #[test]
 fn with_tuple_with_index_in_range_returns_tuple_without_element() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
         &[
             0.into_process(&mut process),
@@ -167,7 +193,9 @@ fn with_tuple_with_index_in_range_returns_tuple_without_element() {
 
 #[test]
 fn with_heap_binary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
     assert_bad_argument!(
@@ -178,7 +206,9 @@ fn with_heap_binary_is_bad_argument() {
 
 #[test]
 fn with_subbinary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/element.rs
+++ b/lumen_runtime/src/otp/erlang/tests/element.rs
@@ -1,10 +1,16 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
+
+use crate::environment::{self, Environment};
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -15,7 +21,9 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::element(Term::EMPTY_LIST, 0.into_process(&mut process)),
@@ -25,7 +33,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(
@@ -36,7 +46,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term: Term = 0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -47,7 +59,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term: Term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -60,7 +74,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -71,7 +87,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(
@@ -82,7 +100,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -93,7 +113,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_without_small_integer_index_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let element_term = 1.into_process(&mut process);
     let tuple_term = Term::slice_to_tuple(&[element_term], &mut process);
     let index = 0usize;
@@ -114,7 +136,9 @@ fn with_tuple_without_small_integer_index_is_bad_argument() {
 
 #[test]
 fn with_tuple_without_index_in_range_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let empty_tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(
@@ -125,7 +149,9 @@ fn with_tuple_without_index_in_range_is_bad_argument() {
 
 #[test]
 fn with_tuple_with_index_in_range_is_element() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let element_term = 1.into_process(&mut process);
     let tuple_term = Term::slice_to_tuple(&[element_term], &mut process);
 
@@ -138,7 +164,9 @@ fn with_tuple_with_index_in_range_is_element() {
 
 #[test]
 fn with_heap_binary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
     assert_bad_argument!(
@@ -149,7 +177,9 @@ fn with_heap_binary_is_bad_argument() {
 
 #[test]
 fn with_subbinary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/head.rs
+++ b/lumen_runtime/src/otp/erlang/tests/head.rs
@@ -1,10 +1,16 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
+
+use crate::environment::{self, Environment};
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::head(atom_term), process);
@@ -12,12 +18,18 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    assert_bad_argument!(erlang::head(Term::EMPTY_LIST), Default::default());
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let process = process_rw_lock.write().unwrap();
+
+    assert_bad_argument!(erlang::head(Term::EMPTY_LIST), process);
 }
 
 #[test]
 fn with_list_returns_head() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let head_term = Term::str_to_atom("head", Existence::DoNotCare, &mut process).unwrap();
     let list_term = Term::cons(head_term, Term::EMPTY_LIST, &mut process);
 
@@ -26,7 +38,9 @@ fn with_list_returns_head() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0.into_process(&mut process);
 
     assert_bad_argument!(erlang::head(small_integer_term), process);
@@ -34,7 +48,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -44,7 +60,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(erlang::head(float_term), process);
@@ -52,7 +70,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(erlang::head(local_pid_term), process);
@@ -60,7 +80,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(erlang::head(external_pid_term), process);
@@ -68,7 +90,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::head(tuple_term), process);
@@ -76,7 +100,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
     assert_bad_argument!(erlang::head(heap_binary_term), process);
@@ -84,7 +110,9 @@ fn with_heap_binary_is_bad_argument() {
 
 #[test]
 fn with_subbinary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/insert_element.rs
+++ b/lumen_runtime/src/otp/erlang/tests/insert_element.rs
@@ -1,10 +1,16 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
+
+use crate::environment::{self, Environment};
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -20,7 +26,9 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::insert_element(
@@ -35,7 +43,9 @@ fn with_empty_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(
@@ -51,7 +61,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -67,7 +79,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -85,7 +99,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -101,7 +117,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(
@@ -117,7 +135,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -133,7 +153,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_without_small_integer_index_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
         &[0.into_process(&mut process), 2.into_process(&mut process)],
         &mut process,
@@ -176,7 +198,9 @@ fn with_tuple_without_small_integer_index_is_bad_argument() {
 
 #[test]
 fn with_tuple_without_index_in_range_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let empty_tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(
@@ -192,7 +216,9 @@ fn with_tuple_without_index_in_range_is_bad_argument() {
 
 #[test]
 fn with_tuple_with_index_in_range_returns_tuple_with_new_element_at_index() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
         &[0.into_process(&mut process), 2.into_process(&mut process)],
         &mut process,
@@ -219,7 +245,9 @@ fn with_tuple_with_index_in_range_returns_tuple_with_new_element_at_index() {
 
 #[test]
 fn with_tuple_with_index_at_size_return_tuples_with_new_element_at_end() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[0.into_process(&mut process)], &mut process);
 
     assert_eq_in_process!(
@@ -239,7 +267,9 @@ fn with_tuple_with_index_at_size_return_tuples_with_new_element_at_end() {
 
 #[test]
 fn with_heap_binary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
     assert_bad_argument!(
@@ -255,7 +285,9 @@ fn with_heap_binary_is_bad_argument() {
 
 #[test]
 fn with_subbinary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/is_atom.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_atom.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_is_true() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_eq_in_process!(
@@ -18,7 +23,9 @@ fn with_atom_is_true() {
 
 #[test]
 fn with_booleans_is_true() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let true_term = true.into_process(&mut process);
     let false_term = false.into_process(&mut process);
 
@@ -32,7 +39,9 @@ fn with_booleans_is_true() {
 
 #[test]
 fn with_nil_is_true() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let nil_term = Term::str_to_atom("nil", Existence::DoNotCare, &mut process).unwrap();
     let true_term = true.into_process(&mut process);
 
@@ -41,7 +50,9 @@ fn with_nil_is_true() {
 
 #[test]
 fn with_empty_list_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let empty_list_term = Term::EMPTY_LIST;
     let false_term = false.into_process(&mut process);
 
@@ -54,7 +65,9 @@ fn with_empty_list_is_false() {
 
 #[test]
 fn with_list_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let head_term = Term::str_to_atom("head", Existence::DoNotCare, &mut process).unwrap();
     let list_term = Term::cons(head_term, Term::EMPTY_LIST, &mut process);
     let false_term = false.into_process(&mut process);
@@ -68,7 +81,9 @@ fn with_list_is_false() {
 
 #[test]
 fn with_small_integer_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0.into_process(&mut process);
     let false_term = false.into_process(&mut process);
 
@@ -81,7 +96,9 @@ fn with_small_integer_is_false() {
 
 #[test]
 fn with_big_integer_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -96,7 +113,9 @@ fn with_big_integer_is_false() {
 
 #[test]
 fn with_float_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
     let false_term = false.into_process(&mut process);
 
@@ -109,7 +128,9 @@ fn with_float_is_false() {
 
 #[test]
 fn with_local_pid_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -122,7 +143,9 @@ fn with_local_pid_is_false() {
 
 #[test]
 fn with_external_pid_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -135,7 +158,9 @@ fn with_external_pid_is_false() {
 
 #[test]
 fn with_tuple_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
     let false_term = false.into_process(&mut process);
 
@@ -148,7 +173,9 @@ fn with_tuple_is_false() {
 
 #[test]
 fn with_heap_binary_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let false_term = false.into_process(&mut process);
 
@@ -161,7 +188,9 @@ fn with_heap_binary_is_false() {
 
 #[test]
 fn with_subbinary_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/is_binary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_binary.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -19,7 +24,9 @@ fn with_atom_is_false() {
 
 #[test]
 fn with_empty_list_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let empty_list_term = Term::EMPTY_LIST;
     let false_term = false.into_process(&mut process);
 
@@ -32,7 +39,9 @@ fn with_empty_list_is_false() {
 
 #[test]
 fn with_list_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let head_term = Term::str_to_atom("head", Existence::DoNotCare, &mut process).unwrap();
     let list_term = Term::cons(head_term, Term::EMPTY_LIST, &mut process);
     let false_term = false.into_process(&mut process);
@@ -46,7 +55,9 @@ fn with_list_is_false() {
 
 #[test]
 fn with_small_integer_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0.into_process(&mut process);
     let false_term = false.into_process(&mut process);
 
@@ -59,7 +70,9 @@ fn with_small_integer_is_false() {
 
 #[test]
 fn with_big_integer_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -74,7 +87,9 @@ fn with_big_integer_is_false() {
 
 #[test]
 fn with_float_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
     let false_term = false.into_process(&mut process);
 
@@ -87,7 +102,9 @@ fn with_float_is_false() {
 
 #[test]
 fn with_local_pid_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -100,7 +117,9 @@ fn with_local_pid_is_false() {
 
 #[test]
 fn with_external_pid_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -113,7 +132,9 @@ fn with_external_pid_is_false() {
 
 #[test]
 fn with_tuple_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
     let false_term = false.into_process(&mut process);
 
@@ -126,7 +147,9 @@ fn with_tuple_is_false() {
 
 #[test]
 fn with_heap_binary_is_true() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let true_term = true.into_process(&mut process);
 
@@ -139,7 +162,9 @@ fn with_heap_binary_is_true() {
 
 #[test]
 fn with_subbinary_with_bit_count_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
@@ -154,7 +179,9 @@ fn with_subbinary_with_bit_count_is_false() {
 
 #[test]
 fn with_subbinary_without_bit_count_is_true() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 0, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/is_integer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_integer.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -19,7 +24,9 @@ fn with_atom_is_false() {
 
 #[test]
 fn with_empty_list_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let empty_list_term = Term::EMPTY_LIST;
     let false_term = false.into_process(&mut process);
 
@@ -32,7 +39,9 @@ fn with_empty_list_is_false() {
 
 #[test]
 fn with_list_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
     let false_term = false.into_process(&mut process);
 
@@ -45,7 +54,9 @@ fn with_list_is_false() {
 
 #[test]
 fn with_small_integer_is_true() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let zero_term = 0usize.into_process(&mut process);
     let true_term = true.into_process(&mut process);
 
@@ -58,7 +69,9 @@ fn with_small_integer_is_true() {
 
 #[test]
 fn with_big_integer_is_true() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -73,7 +86,9 @@ fn with_big_integer_is_true() {
 
 #[test]
 fn with_float_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
     let false_term = false.into_process(&mut process);
 
@@ -86,7 +101,9 @@ fn with_float_is_false() {
 
 #[test]
 fn with_local_pid_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -99,7 +116,9 @@ fn with_local_pid_is_false() {
 
 #[test]
 fn with_external_pid_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -112,7 +131,9 @@ fn with_external_pid_is_false() {
 
 #[test]
 fn with_tuple_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
     let false_term = false.into_process(&mut process);
 
@@ -125,7 +146,9 @@ fn with_tuple_is_false() {
 
 #[test]
 fn with_heap_binary_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let false_term = false.into_process(&mut process);
 
@@ -138,7 +161,9 @@ fn with_heap_binary_is_false() {
 
 #[test]
 fn with_subbinary_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/is_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_list.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -19,7 +24,9 @@ fn with_atom_is_false() {
 
 #[test]
 fn with_empty_list_is_true() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let empty_list_term = Term::EMPTY_LIST;
     let true_term = true.into_process(&mut process);
 
@@ -32,7 +39,9 @@ fn with_empty_list_is_true() {
 
 #[test]
 fn with_list_is_true() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
     let true_term = true.into_process(&mut process);
 
@@ -41,7 +50,9 @@ fn with_list_is_true() {
 
 #[test]
 fn with_small_integer_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0.into_process(&mut process);
     let false_term = false.into_process(&mut process);
 
@@ -54,7 +65,9 @@ fn with_small_integer_is_false() {
 
 #[test]
 fn with_big_integer_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -69,7 +82,9 @@ fn with_big_integer_is_false() {
 
 #[test]
 fn with_float_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
     let false_term = false.into_process(&mut process);
 
@@ -82,7 +97,9 @@ fn with_float_is_false() {
 
 #[test]
 fn with_local_pid_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -95,7 +112,9 @@ fn with_local_pid_is_false() {
 
 #[test]
 fn with_external_pid_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -108,7 +127,9 @@ fn with_external_pid_is_false() {
 
 #[test]
 fn with_tuple_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
     let false_term = false.into_process(&mut process);
 
@@ -121,7 +142,9 @@ fn with_tuple_is_false() {
 
 #[test]
 fn with_heap_binary_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let false_term = false.into_process(&mut process);
 
@@ -134,7 +157,9 @@ fn with_heap_binary_is_false() {
 
 #[test]
 fn with_subbinary_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/is_tuple.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_tuple.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -19,7 +24,9 @@ fn with_atom_is_false() {
 
 #[test]
 fn with_empty_list_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let empty_list_term = Term::EMPTY_LIST;
     let false_term = false.into_process(&mut process);
 
@@ -32,7 +39,9 @@ fn with_empty_list_is_false() {
 
 #[test]
 fn with_list_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
     let false_term = false.into_process(&mut process);
 
@@ -45,7 +54,9 @@ fn with_list_is_false() {
 
 #[test]
 fn with_small_integer_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0.into_process(&mut process);
     let false_term = false.into_process(&mut process);
 
@@ -58,7 +69,9 @@ fn with_small_integer_is_false() {
 
 #[test]
 fn with_big_integer_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -73,7 +86,9 @@ fn with_big_integer_is_false() {
 
 #[test]
 fn with_float_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
     let false_term = false.into_process(&mut process);
 
@@ -86,7 +101,9 @@ fn with_float_is_false() {
 
 #[test]
 fn with_local_pid_is_true() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -99,7 +116,9 @@ fn with_local_pid_is_true() {
 
 #[test]
 fn with_external_pid_is_true() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
     let false_term = false.into_process(&mut process);
 
@@ -112,7 +131,9 @@ fn with_external_pid_is_true() {
 
 #[test]
 fn with_tuple_is_true() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
     let true_term = true.into_process(&mut process);
 
@@ -125,7 +146,9 @@ fn with_tuple_is_true() {
 
 #[test]
 fn with_heap_binary_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
     let false_term = false.into_process(&mut process);
 
@@ -138,7 +161,9 @@ fn with_heap_binary_is_false() {
 
 #[test]
 fn with_subbinary_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/length.rs
+++ b/lumen_runtime/src/otp/erlang/tests/length.rs
@@ -1,10 +1,16 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
+
+use crate::environment::{self, Environment};
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::length(atom_term, &mut process), process);
@@ -12,7 +18,9 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_zero() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let zero_term = 0.into_process(&mut process);
 
     assert_eq_in_process!(
@@ -24,7 +32,9 @@ fn with_empty_list_is_zero() {
 
 #[test]
 fn with_improper_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let head_term = Term::str_to_atom("head", Existence::DoNotCare, &mut process).unwrap();
     let tail_term = Term::str_to_atom("tail", Existence::DoNotCare, &mut process).unwrap();
     let improper_list_term = Term::cons(head_term, tail_term, &mut process);
@@ -34,7 +44,9 @@ fn with_improper_list_is_bad_argument() {
 
 #[test]
 fn with_list_is_length() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = (0..=2).rfold(Term::EMPTY_LIST, |acc, i| {
         Term::cons(i.into_process(&mut process), acc, &mut process)
     });
@@ -48,7 +60,9 @@ fn with_list_is_length() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0.into_process(&mut process);
 
     assert_bad_argument!(erlang::length(small_integer_term, &mut process), process);
@@ -56,7 +70,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -66,7 +82,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(erlang::length(float_term, &mut process), process);
@@ -74,7 +92,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(erlang::length(local_pid_term, &mut process), process);
@@ -82,7 +102,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(erlang::length(external_pid_term, &mut process), process);
@@ -90,7 +112,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::length(tuple_term, &mut process), process);
@@ -98,7 +122,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
     assert_bad_argument!(erlang::length(heap_binary_term, &mut process), process);
@@ -106,7 +132,9 @@ fn with_heap_binary_is_false() {
 
 #[test]
 fn with_subbinary_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/list_to_pid.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_pid.rs
@@ -2,9 +2,15 @@ use super::*;
 
 use num_traits::Num;
 
+use std::sync::{Arc, RwLock};
+
+use crate::environment::{self, Environment};
+
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::list_to_pid(atom_term, &mut process), process);
@@ -12,14 +18,18 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(erlang::list_to_pid(Term::EMPTY_LIST, &mut process), process);
 }
 
 #[test]
 fn with_list_encoding_local_pid() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<", &mut process), &mut process),
@@ -66,7 +76,9 @@ fn with_list_encoding_local_pid() {
 
 #[test]
 fn with_list_encoding_external_pid() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(
         erlang::list_to_pid(Term::str_to_char_list("<", &mut process), &mut process),
@@ -113,7 +125,9 @@ fn with_list_encoding_external_pid() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0.into_process(&mut process);
 
     assert_bad_argument!(
@@ -124,7 +138,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -134,7 +150,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(erlang::list_to_pid(float_term, &mut process), process);
@@ -142,7 +160,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(erlang::list_to_pid(local_pid_term, &mut process), process);
@@ -150,7 +170,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(
@@ -161,7 +183,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::list_to_pid(tuple_term, &mut process), process);
@@ -169,7 +193,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
     assert_bad_argument!(erlang::list_to_pid(heap_binary_term, &mut process), process);
@@ -177,7 +203,9 @@ fn with_heap_binary_is_false() {
 
 #[test]
 fn with_subbinary_is_false() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/self_pid.rs
+++ b/lumen_runtime/src/otp/erlang/tests/self_pid.rs
@@ -1,0 +1,19 @@
+use super::*;
+
+use std::sync::{Arc, RwLock};
+
+use crate::environment::{self, Environment};
+
+#[test]
+fn returns_process_pid() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let process = process_rw_lock.read().unwrap();
+
+    assert_eq_in_process!(erlang::self_pid(&process), process.pid, process);
+    assert_eq_in_process!(
+        erlang::self_pid(&process),
+        Term::local_pid(0, 0).unwrap(),
+        process
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/size.rs
+++ b/lumen_runtime/src/otp/erlang/tests/size.rs
@@ -1,12 +1,17 @@
 use super::*;
 
+use std::sync::{Arc, RwLock};
+
 use num_traits::Num;
 
+use crate::environment::{self, Environment};
 use crate::process::IntoProcess;
 
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::size(atom_term, &mut process), process);
@@ -14,14 +19,18 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
 
     assert_bad_argument!(erlang::size(Term::EMPTY_LIST, &mut process), process);
 }
 
 #[test]
 fn with_list_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let list_term = list_term(&mut process);
 
     assert_bad_argument!(erlang::size(list_term, &mut process), process);
@@ -29,7 +38,9 @@ fn with_list_is_bad_argument() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0usize.into_process(&mut process);
 
     assert_bad_argument!(erlang::size(small_integer_term, &mut process), process);
@@ -37,7 +48,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -47,7 +60,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(erlang::size(float_term, &mut process), process);
@@ -55,7 +70,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(erlang::size(local_pid_term, &mut process), process);
@@ -63,7 +80,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(erlang::size(external_pid_term, &mut process), process);
@@ -71,7 +90,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_without_elements_is_zero() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let empty_tuple_term = Term::slice_to_tuple(&[], &mut process);
     let zero_term = 0usize.into_process(&mut process);
 
@@ -84,7 +105,9 @@ fn with_tuple_without_elements_is_zero() {
 
 #[test]
 fn with_tuple_with_elements_is_element_count() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let element_vec: Vec<Term> = (0..=2usize).map(|i| i.into_process(&mut process)).collect();
     let element_slice: &[Term] = element_vec.as_slice();
     let tuple_term = Term::slice_to_tuple(element_slice, &mut process);
@@ -99,7 +122,9 @@ fn with_tuple_with_elements_is_element_count() {
 
 #[test]
 fn with_heap_binary_is_byte_count() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[0, 1, 2], &mut process);
     let byte_count_term = 3usize.into_process(&mut process);
 
@@ -112,7 +137,9 @@ fn with_heap_binary_is_byte_count() {
 
 #[test]
 fn with_subbinary_with_bit_count_is_byte_count() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
@@ -127,7 +154,9 @@ fn with_subbinary_with_bit_count_is_byte_count() {
 
 #[test]
 fn with_subbinary_without_bit_count_is_byte_count() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 0, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/tail.rs
+++ b/lumen_runtime/src/otp/erlang/tests/tail.rs
@@ -2,9 +2,15 @@ use super::*;
 
 use num_traits::Num;
 
+use std::sync::{Arc, RwLock};
+
+use crate::environment::{self, Environment};
+
 #[test]
 fn with_atom_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
     assert_bad_argument!(erlang::tail(atom_term), process);
@@ -12,12 +18,18 @@ fn with_atom_is_bad_argument() {
 
 #[test]
 fn with_empty_list_is_bad_argument() {
-    assert_bad_argument!(erlang::tail(Term::EMPTY_LIST), Default::default());
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let process = process_rw_lock.read().unwrap();
+
+    assert_bad_argument!(erlang::tail(Term::EMPTY_LIST), process);
 }
 
 #[test]
 fn with_list_returns_tail() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let head_term = Term::str_to_atom("head", Existence::DoNotCare, &mut process).unwrap();
     let list_term = Term::cons(head_term, Term::EMPTY_LIST, &mut process);
 
@@ -26,7 +38,9 @@ fn with_list_returns_tail() {
 
 #[test]
 fn with_small_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let small_integer_term = 0.into_process(&mut process);
 
     assert_bad_argument!(erlang::tail(small_integer_term), process);
@@ -34,7 +48,9 @@ fn with_small_integer_is_bad_argument() {
 
 #[test]
 fn with_big_integer_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
         .unwrap()
         .into_process(&mut process);
@@ -44,7 +60,9 @@ fn with_big_integer_is_bad_argument() {
 
 #[test]
 fn with_float_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let float_term = 1.0.into_process(&mut process);
 
     assert_bad_argument!(erlang::tail(float_term), process);
@@ -52,7 +70,9 @@ fn with_float_is_bad_argument() {
 
 #[test]
 fn with_local_pid_is_bad_argument() {
-    let process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let process = process_rw_lock.read().unwrap();
     let local_pid_term = Term::local_pid(0, 0).unwrap();
 
     assert_bad_argument!(erlang::tail(local_pid_term), process);
@@ -60,7 +80,9 @@ fn with_local_pid_is_bad_argument() {
 
 #[test]
 fn with_external_pid_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
 
     assert_bad_argument!(erlang::tail(external_pid_term), process);
@@ -68,7 +90,9 @@ fn with_external_pid_is_bad_argument() {
 
 #[test]
 fn with_tuple_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
     assert_bad_argument!(erlang::tail(tuple_term), process);
@@ -76,7 +100,9 @@ fn with_tuple_is_bad_argument() {
 
 #[test]
 fn with_heap_binary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
     assert_bad_argument!(erlang::tail(heap_binary_term), process);
@@ -84,7 +110,9 @@ fn with_heap_binary_is_bad_argument() {
 
 #[test]
 fn with_subbinary_is_bad_argument() {
-    let mut process: Process = Default::default();
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
     let binary_term =
         Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
     let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);

--- a/lumen_runtime/src/process/identifier.rs
+++ b/lumen_runtime/src/process/identifier.rs
@@ -43,3 +43,32 @@ impl OrderInProcess for External {
         }
     }
 }
+
+pub struct LocalCounter {
+    serial: usize,
+    number: usize,
+}
+
+impl LocalCounter {
+    pub fn next(&mut self) -> Term {
+        let local_pid = Term::local_pid(self.number, self.serial).unwrap();
+
+        if NUMBER_MAX <= self.number {
+            self.serial += 1;
+            self.number = 0;
+        } else {
+            self.number += 1;
+        }
+
+        local_pid
+    }
+}
+
+impl Default for LocalCounter {
+    fn default() -> LocalCounter {
+        LocalCounter {
+            serial: 0,
+            number: 0,
+        }
+    }
+}

--- a/lumen_runtime/src/term.rs
+++ b/lumen_runtime/src/term.rs
@@ -1082,12 +1082,18 @@ mod tests {
     mod cmp_in_process {
         use super::*;
 
+        use std::sync::{Arc, RwLock};
+
+        use crate::environment::{self, Environment};
+
         mod less {
             use super::*;
 
             #[test]
             fn number_is_less_than_atom() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let number_term: Term = 0.into_process(&mut process);
                 let atom_term = Term::str_to_atom("0", Existence::DoNotCare, &mut process).unwrap();
 
@@ -1097,7 +1103,9 @@ mod tests {
 
             #[test]
             fn atom_is_less_than_tuple() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let atom_term = Term::str_to_atom("0", Existence::DoNotCare, &mut process).unwrap();
                 let tuple_term = Term::slice_to_tuple(&[], &mut process);
 
@@ -1107,7 +1115,9 @@ mod tests {
 
             #[test]
             fn atom_is_less_than_atom_if_name_is_less_than() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let greater_name = "b";
                 let greater_term =
                     Term::str_to_atom(greater_name, Existence::DoNotCare, &mut process).unwrap();
@@ -1127,7 +1137,9 @@ mod tests {
 
             #[test]
             fn shorter_tuple_is_less_than_longer_tuple() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let shorter_tuple = Term::slice_to_tuple(&[], &mut process);
                 let longer_tuple =
                     Term::slice_to_tuple(&[0.into_process(&mut process)], &mut process);
@@ -1138,7 +1150,9 @@ mod tests {
 
             #[test]
             fn same_length_tuples_with_lesser_elements_is_lesser() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let lesser_tuple =
                     Term::slice_to_tuple(&[0.into_process(&mut process)], &mut process);
                 let greater_tuple =
@@ -1150,7 +1164,9 @@ mod tests {
 
             #[test]
             fn tuple_is_less_than_empty_list() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let tuple_term = Term::slice_to_tuple(&[], &mut process);
                 let empty_list_term = Term::EMPTY_LIST;
 
@@ -1160,7 +1176,9 @@ mod tests {
 
             #[test]
             fn tuple_is_less_than_list() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let tuple_term = Term::slice_to_tuple(&[], &mut process);
                 let list_term = list_term(&mut process);
 
@@ -1174,7 +1192,9 @@ mod tests {
 
             #[test]
             fn with_improper_list() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let list_term = Term::cons(
                     0.into_process(&mut process),
                     1.into_process(&mut process),
@@ -1198,7 +1218,9 @@ mod tests {
 
             #[test]
             fn with_proper_list() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let list_term =
                     Term::cons(0.into_process(&mut process), Term::EMPTY_LIST, &mut process);
                 let equal_list_term =
@@ -1213,7 +1235,9 @@ mod tests {
 
             #[test]
             fn with_nested_list() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let list_term = Term::cons(
                     0.into_process(&mut process),
                     Term::cons(1.into_process(&mut process), Term::EMPTY_LIST, &mut process),
@@ -1237,7 +1261,9 @@ mod tests {
 
             #[test]
             fn with_lists_of_unequal_length() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let list_term = Term::cons(
                     0.into_process(&mut process),
                     Term::cons(1.into_process(&mut process), Term::EMPTY_LIST, &mut process),
@@ -1268,7 +1294,9 @@ mod tests {
 
             #[test]
             fn with_tuples_of_unequal_length() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let tuple_term =
                     Term::slice_to_tuple(&[0.into_process(&mut process)], &mut process);
                 let equal_term =
@@ -1285,7 +1313,9 @@ mod tests {
 
             #[test]
             fn with_heap_binaries_of_unequal_length() {
-                let mut process: Process = Default::default();
+                let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+                let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+                let mut process = process_rw_lock.write().unwrap();
                 let heap_binary_term = Term::slice_to_binary(&[0, 1], &mut process);
                 let equal_heap_binary_term = Term::slice_to_binary(&[0, 1], &mut process);
                 let shorter_heap_binary_term = Term::slice_to_binary(&[0], &mut process);
@@ -1302,9 +1332,15 @@ mod tests {
     mod is_empty_list {
         use super::*;
 
+        use std::sync::{Arc, RwLock};
+
+        use crate::environment::{self, Environment};
+
         #[test]
         fn with_atom_is_false() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
 
             assert_eq!(atom_term.is_empty_list(), false);
@@ -1317,7 +1353,9 @@ mod tests {
 
         #[test]
         fn with_list_is_false() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let head_term = Term::str_to_atom("head", Existence::DoNotCare, &mut process).unwrap();
             let list_term = Term::cons(head_term, Term::EMPTY_LIST, &mut process);
 
@@ -1326,7 +1364,9 @@ mod tests {
 
         #[test]
         fn with_small_integer_is_false() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let small_integer_term = small_integer_term(&mut process, 0);
 
             assert_eq!(small_integer_term.is_empty_list(), false);
@@ -1334,7 +1374,9 @@ mod tests {
 
         #[test]
         fn with_tuple_is_false() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let tuple_term = tuple_term(&mut process);
 
             assert_eq!(tuple_term.is_empty_list(), false);
@@ -1342,7 +1384,9 @@ mod tests {
 
         #[test]
         fn with_heap_binary_is_false() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let heap_binary_term = Term::slice_to_binary(&[], &mut process);
 
             assert_eq!(heap_binary_term.is_empty_list(), false);

--- a/lumen_runtime/src/tuple.rs
+++ b/lumen_runtime/src/tuple.rs
@@ -216,11 +216,16 @@ mod tests {
     mod from_slice {
         use super::*;
 
+        use std::sync::{Arc, RwLock};
+
+        use crate::environment::{self, Environment};
         use crate::process::IntoProcess;
 
         #[test]
         fn without_elements() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let tuple = Tuple::from_slice(&[], &mut process.term_arena);
 
             let tuple_pointer = tuple as *const Tuple;
@@ -230,7 +235,9 @@ mod tests {
 
         #[test]
         fn with_elements() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let tuple = Tuple::from_slice(&[0.into_process(&mut process)], &mut process.term_arena);
 
             let tuple_pointer = tuple as *const Tuple;
@@ -249,11 +256,16 @@ mod tests {
     mod element {
         use super::*;
 
+        use std::sync::{Arc, RwLock};
+
+        use crate::environment::{self, Environment};
         use crate::process::IntoProcess;
 
         #[test]
         fn without_valid_index() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let tuple = Tuple::from_slice(&[], &mut process.term_arena);
 
             assert_eq_in_process!(tuple.element(0), Err(bad_argument!()), process);
@@ -261,7 +273,9 @@ mod tests {
 
         #[test]
         fn with_valid_index() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let tuple = Tuple::from_slice(&[0.into_process(&mut process)], &mut process.term_arena);
 
             assert_eq_in_process!(tuple.element(0), Ok(0.into_process(&mut process)), process);
@@ -271,11 +285,16 @@ mod tests {
     mod eq {
         use super::*;
 
+        use std::sync::{Arc, RwLock};
+
+        use crate::environment::{self, Environment};
         use crate::process::IntoProcess;
 
         #[test]
         fn without_element() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let tuple = Tuple::from_slice(&[], &mut process.term_arena);
             let equal = Tuple::from_slice(&[], &mut process.term_arena);
 
@@ -285,7 +304,9 @@ mod tests {
 
         #[test]
         fn with_unequal_length() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let tuple = Tuple::from_slice(&[0.into_process(&mut process)], &mut process.term_arena);
             let unequal = Tuple::from_slice(
                 &[0.into_process(&mut process), 1.into_process(&mut process)],
@@ -300,12 +321,16 @@ mod tests {
         use super::*;
 
         use std::convert::TryInto;
+        use std::sync::{Arc, RwLock};
 
+        use crate::environment::{self, Environment};
         use crate::process::IntoProcess;
 
         #[test]
         fn without_elements() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let tuple = Tuple::from_slice(&[], &mut process.term_arena);
 
             assert_eq!(tuple.iter().count(), 0);
@@ -317,7 +342,9 @@ mod tests {
 
         #[test]
         fn with_elements() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let tuple = Tuple::from_slice(&[0.into_process(&mut process)], &mut process.term_arena);
 
             assert_eq!(tuple.iter().count(), 1);
@@ -331,11 +358,16 @@ mod tests {
     mod size {
         use super::*;
 
+        use std::sync::{Arc, RwLock};
+
+        use crate::environment::{self, Environment};
         use crate::process::IntoProcess;
 
         #[test]
         fn without_elements() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
             let tuple = Tuple::from_slice(&[], &mut process.term_arena);
 
             assert_eq_in_process!(tuple.size(), &0.into(), process);
@@ -343,7 +375,10 @@ mod tests {
 
         #[test]
         fn with_elements() {
-            let mut process: Process = Default::default();
+            let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+            let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+            let mut process = process_rw_lock.write().unwrap();
+
             let tuple = Tuple::from_slice(&[0.into_process(&mut process)], &mut process.term_arena);
 
             assert_eq_in_process!(tuple.size(), &1.into(), process);


### PR DESCRIPTION
# Changelog
## Enhancements
* `Environment` keeps track of processes in a `HashMap<usize, Arc<RwLock<Process>>`, `process_by_pid_tagged`.  Since the `Environment` has a strong reference to the `Process`, the `Process`'s `environment` had to downgraded from `Arc<RwLock<Environment>>` to `Weak<RwLock<Environment>>`.

  Since the `Process` only held a weak reference to the `Environment`, the `Environment` could be dropped before the atom table could be accessed when doing

  ```
  let process: Process: Default::default();
  ```

  To hold a strong reference to the environment, `impl Default for Process` has been removed and tests changed to setup as

  ```
  let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
  let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
  let mut process = process_rw_lock.write().unwrap();
  ```

  Because the `RwLockWriteGuard` from `process_rw_lock.write().unwrap()` does not support multiple `&mut` to fields in the `Process` struct, functions that took two multiple references to different fields, such as `Binary::from_slice` using both the binary and byte arenas did not work, so the functions were changed to take `&mut Process` which accepts `RwLockWriteGuard` because the auto-Deref allows that.
* Adds `:erlang.self()` as `erlang::self_pid()` since `self` is a keyword in Rust.
## Incompatible Changes