### PR TITLE
is_record/3

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -601,6 +601,24 @@ pub fn is_pid(term: Term, mut process: &mut Process) -> Term {
 }
 
 pub fn is_record(term: Term, record_tag: Term, mut process: &mut Process) -> Result {
+    is_record_with_option_size(term, record_tag, None, &mut process)
+}
+
+pub fn is_record_with_size(
+    term: Term,
+    record_tag: Term,
+    size: Term,
+    mut process: &mut Process,
+) -> Result {
+    is_record_with_option_size(term, record_tag, Some(size), &mut process)
+}
+
+fn is_record_with_option_size(
+    term: Term,
+    record_tag: Term,
+    size: Option<Term>,
+    mut process: &mut Process,
+) -> Result {
     match term.tag() {
         Tag::Boxed => {
             let unboxed: &Term = term.unbox_reference();
@@ -609,7 +627,7 @@ pub fn is_record(term: Term, record_tag: Term, mut process: &mut Process) -> Res
                 Tag::Arity => {
                     let tuple: &Tuple = term.unbox_reference();
 
-                    tuple.is_record(record_tag, &mut process)
+                    tuple.is_record(record_tag, size, &mut process)
                 }
                 _ => Ok(false.into_process(&mut process)),
             }

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -38,6 +38,7 @@ mod is_map_key;
 mod is_number;
 mod is_pid;
 mod is_record;
+mod is_record_with_size;
 mod is_tuple;
 mod length;
 mod list_to_pid;

--- a/lumen_runtime/src/otp/erlang/tests/is_record_with_size.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_record_with_size.rs
@@ -1,0 +1,190 @@
+use super::*;
+
+use std::sync::{Arc, RwLock};
+
+use num_traits::Num;
+
+use crate::atom::Existence::DoNotCare;
+use crate::environment::{self, Environment};
+use crate::process::IntoProcess;
+
+mod with_tuple;
+
+#[test]
+fn with_atom_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let term = Term::str_to_atom("term", DoNotCare, &mut process).unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let size = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        Ok(false.into_process(&mut process)),
+        process
+    );
+}
+
+#[test]
+fn with_empty_list_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let term = Term::EMPTY_LIST;
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let size = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        Ok(false.into_process(&mut process)),
+        process
+    );
+}
+
+#[test]
+fn with_list_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let term = list_term(&mut process);
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let size = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        Ok(false.into_process(&mut process)),
+        process
+    );
+}
+
+#[test]
+fn with_small_integer_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let term = 0.into_process(&mut process);
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let size = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        Ok(false.into_process(&mut process)),
+        process
+    );
+}
+
+#[test]
+fn with_big_integer_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
+        .unwrap()
+        .into_process(&mut process);
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let size = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        Ok(false.into_process(&mut process)),
+        process
+    );
+}
+
+#[test]
+fn with_float_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let term = 1.0.into_process(&mut process);
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let size = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        Ok(false.into_process(&mut process)),
+        process
+    );
+}
+
+#[test]
+fn with_local_pid_is_true() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let term = Term::local_pid(0, 0, &mut process).unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let size = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        Ok(false.into_process(&mut process)),
+        process
+    );
+}
+
+#[test]
+fn with_external_pid_is_true() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let term = Term::external_pid(1, 0, 0, &mut process).unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let size = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        Ok(false.into_process(&mut process)),
+        process
+    );
+}
+
+#[test]
+fn with_map_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let term = Term::slice_to_map(&[], &mut process);
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let size = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        Ok(false.into_process(&mut process)),
+        process
+    );
+}
+
+#[test]
+fn with_heap_binary_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let term = Term::slice_to_binary(&[], &mut process);
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let size = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        Ok(false.into_process(&mut process)),
+        process
+    );
+}
+
+#[test]
+fn with_subbinary_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let original = Term::slice_to_binary(&[129, 0b0000_0000], &mut process);
+    let term = Term::subbinary(original, 0, 1, 1, 0, &mut process);
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let size = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        Ok(false.into_process(&mut process)),
+        process
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/is_record_with_size/with_tuple.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_record_with_size/with_tuple.rs
@@ -1,0 +1,178 @@
+use super::*;
+
+use std::sync::{Arc, RwLock};
+
+use num_traits::Num;
+
+use crate::environment::{self, Environment};
+use crate::process::IntoProcess;
+
+mod with_atom_record_tag;
+
+#[test]
+fn with_empty_list_record_tag_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::EMPTY_LIST;
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_list_record_tag_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = list_term(&mut process);
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_small_integer_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = 0.into_process(&mut process);
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_big_integer_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = <BigInt as Num>::from_str_radix("576460752303423489", 10)
+        .unwrap()
+        .into_process(&mut process);
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_float_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = 1.0.into_process(&mut process);
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_local_pid_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::local_pid(0, 0, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_external_pid_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::external_pid(1, 0, 0, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_tuple_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::slice_to_tuple(&[], &mut process);
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_map_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::slice_to_map(&[], &mut process);
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_heap_binary_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::slice_to_binary(&[], &mut process);
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_subbinary_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let original = Term::slice_to_binary(&[129, 0b0000_0000], &mut process);
+    let record_tag = Term::subbinary(original, 0, 1, 1, 0, &mut process);
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/is_record_with_size/with_tuple/with_atom_record_tag.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_record_with_size/with_tuple/with_atom_record_tag.rs
@@ -1,0 +1,201 @@
+use super::*;
+
+use std::sync::{Arc, RwLock};
+
+use num_traits::Num;
+
+use crate::atom::Existence::DoNotCare;
+use crate::environment::{self, Environment};
+use crate::process::IntoProcess;
+
+#[test]
+fn with_atom_size_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = Term::str_to_atom("1", DoNotCare, &mut process).unwrap();
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_empty_list_size_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = Term::EMPTY_LIST;
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_list_size_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = list_term(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_small_integer() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        Ok(true.into_process(&mut process)),
+        process
+    );
+
+    let other_size = 2.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_record_with_size(term, record_tag, other_size, &mut process),
+        Ok(false.into_process(&mut process)),
+        process
+    );
+}
+
+#[test]
+fn with_big_integer_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = <BigInt as Num>::from_str_radix("576460752303423489", 10)
+        .unwrap()
+        .into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_float_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = 1.0.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_local_pid_errors_badard() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = Term::local_pid(0, 0, &mut process).unwrap();
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_external_pid_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = Term::external_pid(1, 0, 0, &mut process).unwrap();
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_tuple_is_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = Term::slice_to_tuple(&[], &mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_map_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = Term::slice_to_map(&[], &mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_heap_binary_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let size = Term::slice_to_binary(&[], &mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_subbinary_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let record_tag = Term::str_to_atom("record_tag", DoNotCare, &mut process).unwrap();
+    let term = Term::slice_to_tuple(&[record_tag], &mut process);
+    let original = Term::slice_to_binary(&[129, 0b0000_0000], &mut process);
+    let size = Term::subbinary(original, 0, 1, 1, 0, &mut process);
+
+    assert_bad_argument!(
+        erlang::is_record_with_size(term, record_tag, size, &mut process),
+        &mut process
+    );
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `:erlang.is_record/3` implemented as `erlang;:is_record_with_size`