### PR TITLE
is_reference/1

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -598,6 +598,21 @@ pub fn is_record_3(term: Term, record_tag: Term, size: Term, mut process: &mut P
     is_record(term, record_tag, Some(size), &mut process)
 }
 
+pub fn is_reference_1(term: Term, mut process: &mut Process) -> Term {
+    match term.tag() {
+        Tag::Boxed => {
+            let unboxed: &Term = term.unbox_reference();
+
+            match unboxed.tag() {
+                Tag::LocalReference | Tag::ExternalReference => true,
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+    .into_process(&mut process)
+}
+
 pub fn is_tuple_1(term: Term, mut process: &mut Process) -> Term {
     (term.tag() == Tag::Boxed && term.unbox_reference::<Term>().tag() == Tag::Arity)
         .into_process(&mut process)

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -39,6 +39,7 @@ mod is_number_1;
 mod is_pid_1;
 mod is_record_2;
 mod is_record_3;
+mod is_reference_1;
 mod is_tuple_1;
 mod length_1;
 mod list_to_pid_1;

--- a/lumen_runtime/src/otp/erlang/tests/is_reference_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_reference_1.rs
@@ -1,0 +1,194 @@
+use super::*;
+
+use std::sync::{Arc, RwLock};
+
+use num_traits::Num;
+
+use crate::environment::{self, Environment};
+use crate::process::IntoProcess;
+
+#[test]
+fn with_atom_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let atom_term = Term::str_to_atom("atom", Existence::DoNotCare, &mut process).unwrap();
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(atom_term, &mut process),
+        false.into_process(&mut process),
+        process
+    );
+}
+
+#[test]
+fn with_local_reference_is_true() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let term = Term::local_reference(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(term, &mut process),
+        true.into_process(&mut process),
+        process
+    );
+}
+
+#[test]
+fn with_empty_list_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let empty_list_term = Term::EMPTY_LIST;
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(empty_list_term, &mut process),
+        false.into_process(&mut process),
+        process
+    );
+}
+
+#[test]
+fn with_list_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list_term = list_term(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(list_term, &mut process),
+        false.into_process(&mut process),
+        process
+    );
+}
+
+#[test]
+fn with_small_integer_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let small_integer_term = 0.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(small_integer_term, &mut process),
+        false.into_process(&mut process),
+        process
+    );
+}
+
+#[test]
+fn with_big_integer_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let big_integer_term = <BigInt as Num>::from_str_radix("576460752303423489", 10)
+        .unwrap()
+        .into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(big_integer_term, &mut process),
+        false.into_process(&mut process),
+        process
+    );
+}
+
+#[test]
+fn with_float_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let float_term = 1.0.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(float_term, &mut process),
+        false.into_process(&mut process),
+        process
+    );
+}
+
+#[test]
+fn with_local_pid_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let local_pid_term = Term::local_pid(0, 0, &mut process).unwrap();
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(local_pid_term, &mut process),
+        false.into_process(&mut process),
+        process
+    );
+}
+
+#[test]
+fn with_external_pid_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let external_pid_term = Term::external_pid(1, 0, 0, &mut process).unwrap();
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(external_pid_term, &mut process),
+        false.into_process(&mut process),
+        process
+    );
+}
+
+#[test]
+fn with_tuple_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let tuple_term = Term::slice_to_tuple(&[], &mut process);
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(tuple_term, &mut process),
+        false.into_process(&mut process),
+        process
+    );
+}
+
+#[test]
+fn with_map_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let map_term = Term::slice_to_map(&[], &mut process);
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(map_term, &mut process),
+        false.into_process(&mut process),
+        process
+    );
+}
+
+#[test]
+fn with_heap_binary_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let heap_binary_term = Term::slice_to_binary(&[], &mut process);
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(heap_binary_term, &mut process),
+        false.into_process(&mut process),
+        process
+    );
+}
+
+#[test]
+fn with_subbinary_is_false() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let binary_term =
+        Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+    let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
+
+    assert_eq_in_process!(
+        erlang::is_reference_1(subbinary_term, &mut process),
+        false.into_process(&mut process),
+        process
+    );
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `:erlang.is_reference/1`.
  
  `true` for local and external references, but only tested with local references since external references require implementing nodes, which will be put off until distribution is required.