### PR TITLE
Use 1-based indexing for tuple functions

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -19,7 +19,7 @@ use crate::otp;
 use crate::process::{IntoProcess, Process, TryIntoInProcess};
 use crate::term::{Tag, Term};
 use crate::time;
-use crate::tuple::Tuple;
+use crate::tuple::{Tuple, ZeroBasedIndex};
 
 #[cfg(test)]
 mod tests;
@@ -407,18 +407,18 @@ pub fn convert_time_unit_3(
 
 pub fn delete_element_2(tuple: Term, index: Term, mut process: &mut Process) -> Result {
     let initial_inner_tuple: &Tuple = tuple.try_into_in_process(&mut process)?;
-    let inner_index: usize = index.try_into_in_process(&mut process)?;
+    let index_zero_based: ZeroBasedIndex = index.try_into_in_process(&mut process)?;
 
     initial_inner_tuple
-        .delete_element(inner_index, &mut process)
+        .delete_element(index_zero_based, &mut process)
         .map(|final_inner_tuple| final_inner_tuple.into())
 }
 
 pub fn element_2(tuple: Term, index: Term, mut process: &mut Process) -> Result {
     let inner_tuple: &Tuple = tuple.try_into_in_process(&mut process)?;
-    let inner_index: usize = index.try_into_in_process(&mut process)?;
+    let index_zero_based: ZeroBasedIndex = index.try_into_in_process(&mut process)?;
 
-    inner_tuple.element(inner_index, &mut process)
+    inner_tuple.element(index_zero_based, &mut process)
 }
 
 pub fn error_1(reason: Term) -> Result {
@@ -442,10 +442,10 @@ pub fn insert_element_3(
     mut process: &mut Process,
 ) -> Result {
     let initial_inner_tuple: &Tuple = tuple.try_into_in_process(&mut process)?;
-    let inner_index: usize = index.try_into_in_process(&mut process)?;
+    let index_zero_based: ZeroBasedIndex = index.try_into_in_process(&mut process)?;
 
     initial_inner_tuple
-        .insert_element(inner_index, element, &mut process)
+        .insert_element(index_zero_based, element, &mut process)
         .map(|final_inner_tuple| final_inner_tuple.into())
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_term_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_term_2.rs
@@ -152,7 +152,7 @@ fn with_used_with_binary_returns_how_many_bytes_were_consumed_along_with_term() 
     // Using only `used` portion of binary returns the same result
 
     let tuple = result.unwrap();
-    let used_term = erlang::element_2(tuple, 1.into_process(&mut process), &mut process).unwrap();
+    let used_term = erlang::element_2(tuple, 2.into_process(&mut process), &mut process).unwrap();
     let used: usize = used_term.try_into_in_process(&mut process).unwrap();
 
     let prefix_term = Term::subbinary(binary_term, 0, 0, used, 0, &mut process);

--- a/lumen_runtime/src/otp/erlang/tests/delete_element_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/delete_element_2.rs
@@ -139,13 +139,13 @@ fn with_tuple_without_small_integer_index_is_bad_argument() {
     let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
         &[
-            0.into_process(&mut process),
             1.into_process(&mut process),
             2.into_process(&mut process),
+            3.into_process(&mut process),
         ],
         &mut process,
     );
-    let index = 1usize;
+    let index = 2usize;
     let invalid_index_term = Term::arity(index);
 
     assert_ne!(invalid_index_term.tag(), Tag::SmallInteger);
@@ -160,7 +160,7 @@ fn with_tuple_without_small_integer_index_is_bad_argument() {
     assert_eq_in_process!(
         erlang::delete_element_2(tuple_term, valid_index_term, &mut process),
         Ok(Term::slice_to_tuple(
-            &[0.into_process(&mut process), 2.into_process(&mut process)],
+            &[1.into_process(&mut process), 3.into_process(&mut process)],
             &mut process
         )),
         process
@@ -187,17 +187,17 @@ fn with_tuple_with_index_in_range_returns_tuple_without_element() {
     let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
         &[
-            0.into_process(&mut process),
             1.into_process(&mut process),
             2.into_process(&mut process),
+            3.into_process(&mut process),
         ],
         &mut process,
     );
 
     assert_eq_in_process!(
-        erlang::delete_element_2(tuple_term, 1.into_process(&mut process), &mut process),
+        erlang::delete_element_2(tuple_term, 2.into_process(&mut process), &mut process),
         Ok(Term::slice_to_tuple(
-            &[0.into_process(&mut process), 2.into_process(&mut process)],
+            &[1.into_process(&mut process), 3.into_process(&mut process)],
             &mut process
         )),
         process

--- a/lumen_runtime/src/otp/erlang/tests/element_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/element_2.rs
@@ -139,7 +139,7 @@ fn with_tuple_without_small_integer_index_is_bad_argument() {
     let mut process = process_rw_lock.write().unwrap();
     let element_2_term = 1.into_process(&mut process);
     let tuple_term = Term::slice_to_tuple(&[element_2_term], &mut process);
-    let index = 0usize;
+    let index = 1usize;
     let invalid_index_term = Term::arity(index);
 
     assert_ne!(invalid_index_term.tag(), Tag::SmallInteger);
@@ -155,6 +155,19 @@ fn with_tuple_without_small_integer_index_is_bad_argument() {
         erlang::element_2(tuple_term, valid_index_term, &mut process),
         Ok(element_2_term),
         process
+    );
+}
+
+#[test]
+fn with_tuple_with_zero_index_is_bad_argument() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let tuple = Term::slice_to_tuple(&[1.into_process(&mut process)], &mut process);
+
+    assert_bad_argument!(
+        erlang::element_2(tuple, 0.into_process(&mut process), &mut process),
+        &mut process
     );
 }
 
@@ -176,12 +189,12 @@ fn with_tuple_with_index_in_range_is_element_2() {
     let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
     let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
     let mut process = process_rw_lock.write().unwrap();
-    let element_2_term = 1.into_process(&mut process);
-    let tuple_term = Term::slice_to_tuple(&[element_2_term], &mut process);
+    let element = 1.into_process(&mut process);
+    let tuple = Term::slice_to_tuple(&[element], &mut process);
 
     assert_eq_in_process!(
-        erlang::element_2(tuple_term, 0.into_process(&mut process), &mut process),
-        Ok(element_2_term),
+        erlang::element_2(tuple, 1.into_process(&mut process), &mut process),
+        Ok(element),
         process
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/insert_element_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/insert_element_3.rs
@@ -175,10 +175,10 @@ fn with_tuple_without_small_integer_index_is_bad_argument() {
     let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
     let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
-        &[0.into_process(&mut process), 2.into_process(&mut process)],
+        &[1.into_process(&mut process), 3.into_process(&mut process)],
         &mut process,
     );
-    let index = 1usize;
+    let index = 2usize;
     let invalid_index_term = Term::arity(index);
 
     assert_ne!(invalid_index_term.tag(), Tag::SmallInteger);
@@ -199,14 +199,14 @@ fn with_tuple_without_small_integer_index_is_bad_argument() {
         erlang::insert_element_3(
             tuple_term,
             valid_index_term,
-            1.into_process(&mut process),
+            2.into_process(&mut process),
             &mut process
         ),
         Ok(Term::slice_to_tuple(
             &[
-                0.into_process(&mut process),
                 1.into_process(&mut process),
-                2.into_process(&mut process)
+                2.into_process(&mut process),
+                3.into_process(&mut process)
             ],
             &mut process
         )),
@@ -224,7 +224,7 @@ fn with_tuple_without_index_in_range_is_bad_argument() {
     assert_bad_argument!(
         erlang::insert_element_3(
             empty_tuple_term,
-            1.into_process(&mut process),
+            2.into_process(&mut process),
             0.into_process(&mut process),
             &mut process
         ),
@@ -238,22 +238,22 @@ fn with_tuple_with_index_in_range_returns_tuple_with_new_element_at_index() {
     let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
     let mut process = process_rw_lock.write().unwrap();
     let tuple_term = Term::slice_to_tuple(
-        &[0.into_process(&mut process), 2.into_process(&mut process)],
+        &[1.into_process(&mut process), 3.into_process(&mut process)],
         &mut process,
     );
 
     assert_eq_in_process!(
         erlang::insert_element_3(
             tuple_term,
-            1.into_process(&mut process),
-            1.into_process(&mut process),
+            2.into_process(&mut process),
+            2.into_process(&mut process),
             &mut process
         ),
         Ok(Term::slice_to_tuple(
             &[
-                0.into_process(&mut process),
                 1.into_process(&mut process),
-                2.into_process(&mut process)
+                2.into_process(&mut process),
+                3.into_process(&mut process)
             ],
             &mut process
         )),
@@ -266,17 +266,17 @@ fn with_tuple_with_index_at_size_return_tuples_with_new_element_at_end() {
     let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
     let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
     let mut process = process_rw_lock.write().unwrap();
-    let tuple_term = Term::slice_to_tuple(&[0.into_process(&mut process)], &mut process);
+    let tuple_term = Term::slice_to_tuple(&[1.into_process(&mut process)], &mut process);
 
     assert_eq_in_process!(
         erlang::insert_element_3(
             tuple_term,
-            1.into_process(&mut process),
-            1.into_process(&mut process),
+            2.into_process(&mut process),
+            3.into_process(&mut process),
             &mut process
         ),
         Ok(Term::slice_to_tuple(
-            &[0.into_process(&mut process), 1.into_process(&mut process)],
+            &[1.into_process(&mut process), 3.into_process(&mut process)],
             &mut process
         )),
         process


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Originally, I had planned to use `0`-based indexing for the tuple functions and then translate from the `1`-based indexing at some boundary, but since the `erlang` module functions will be called
directly, they need to exactly implement the Erlang convention.

  I've kept the 0-based indexing inside of Tuple and added newtypes, OneBasedIndex and ZeroBasedIndex, to make it clear what indexing is expected in each place.