### PR TITLE
++/2

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -390,6 +390,19 @@ pub fn ceil_1(number: Term, mut process: &mut Process) -> Result {
     }
 }
 
+/// `++/2`
+pub fn concatenate_2(list: Term, term: Term, mut process: &mut Process) -> Result {
+    match list.tag() {
+        EmptyList => Ok(term),
+        List => {
+            let cons: &Cons = unsafe { list.as_ref_cons_unchecked() };
+
+            cons.concatenate(term, &mut process)
+        }
+        _ => Err(bad_argument!(&mut process)),
+    }
+}
+
 pub fn convert_time_unit_3(
     time: Term,
     from_unit: Term,

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -20,6 +20,7 @@ mod bit_size_1;
 mod bitstring_to_list_1;
 mod byte_size_1;
 mod ceil_1;
+mod concatenate_2;
 mod convert_time_unit_3;
 mod delete_element_2;
 mod element_2;

--- a/lumen_runtime/src/otp/erlang/tests/concatenate_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/concatenate_2.rs
@@ -1,0 +1,192 @@
+use super::*;
+
+use num_traits::Num;
+
+use std::sync::{Arc, RwLock};
+
+use crate::environment::{self, Environment};
+
+mod with_empty_list;
+mod with_list;
+
+#[test]
+fn with_atom_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::str_to_atom("list", DoNotCare, &mut process).unwrap();
+    let term = Term::str_to_atom("term", DoNotCare, &mut process).unwrap();
+
+    assert_bad_argument!(
+        erlang::concatenate_2(list, term, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_local_reference_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::local_reference(&mut process);
+    let term = Term::local_reference(&mut process);
+
+    assert_bad_argument!(
+        erlang::concatenate_2(list, term, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_improper_list_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::cons(
+        0.into_process(&mut process),
+        1.into_process(&mut process),
+        &mut process,
+    );
+    let term = Term::cons(
+        2.into_process(&mut process),
+        3.into_process(&mut process),
+        &mut process,
+    );
+
+    assert_bad_argument!(
+        erlang::concatenate_2(list, term, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_small_integer_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = 0.into_process(&mut process);
+    let term = 1.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::concatenate_2(list, term, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_big_integer_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = <BigInt as Num>::from_str_radix("576460752303423489", 10)
+        .unwrap()
+        .into_process(&mut process);
+    let term = <BigInt as Num>::from_str_radix("576460752303423490", 10)
+        .unwrap()
+        .into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::concatenate_2(list, term, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_float_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = 1.0.into_process(&mut process);
+    let term = 2.0.into_process(&mut process);
+
+    assert_bad_argument!(
+        erlang::concatenate_2(list, term, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_local_pid_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::local_pid(0, 1, &mut process).unwrap();
+    let term = Term::local_pid(1, 2, &mut process).unwrap();
+
+    assert_bad_argument!(
+        erlang::concatenate_2(list, term, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_external_pid_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::external_pid(1, 2, 3, &mut process).unwrap();
+    let term = Term::external_pid(4, 5, 6, &mut process).unwrap();
+
+    assert_bad_argument!(
+        erlang::concatenate_2(list, term, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_tuple_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::slice_to_tuple(&[], &mut process);
+    let term = Term::slice_to_tuple(&[], &mut process);
+
+    assert_bad_argument!(
+        erlang::concatenate_2(list, term, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_map_is_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::slice_to_map(&[], &mut process);
+    let term = Term::slice_to_map(&[], &mut process);
+
+    assert_bad_argument!(
+        erlang::concatenate_2(list, term, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_heap_binary_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::slice_to_binary(&[], &mut process);
+    let term = Term::slice_to_binary(&[], &mut process);
+
+    assert_bad_argument!(
+        erlang::concatenate_2(list, term, &mut process),
+        &mut process
+    );
+}
+
+#[test]
+fn with_subbinary_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let binary_term =
+        Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+    let list = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
+    let term = Term::subbinary(binary_term, 0, 7, 2, 0, &mut process);
+
+    assert_bad_argument!(
+        erlang::concatenate_2(list, term, &mut process),
+        &mut process
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/concatenate_2/with_empty_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/concatenate_2/with_empty_list.rs
@@ -1,0 +1,198 @@
+use super::*;
+
+use num_traits::Num;
+
+use std::sync::{Arc, RwLock};
+
+use crate::environment::{self, Environment};
+
+// The behavior here is weird to @KronicDeth and @bitwalker, but consistent with BEAM.
+// See https://bugs.erlang.org/browse/ERL-898.
+
+#[test]
+fn with_atom_returns_atom() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::EMPTY_LIST;
+    let term = Term::str_to_atom("term", DoNotCare, &mut process).unwrap();
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(term),
+        &mut process
+    );
+}
+
+#[test]
+fn with_local_reference_returns_local_reference() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::EMPTY_LIST;
+    let term = Term::local_reference(&mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(term),
+        &mut process
+    );
+}
+
+#[test]
+fn with_improper_list_returns_improper_list() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::EMPTY_LIST;
+    let term = Term::cons(
+        2.into_process(&mut process),
+        3.into_process(&mut process),
+        &mut process,
+    );
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(term),
+        &mut process
+    );
+}
+
+#[test]
+fn with_small_integer_returns_small_integer() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::EMPTY_LIST;
+    let term = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(term),
+        &mut process
+    );
+}
+
+#[test]
+fn with_big_integer_returns_big_integer() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::EMPTY_LIST;
+    let term = <BigInt as Num>::from_str_radix("576460752303423490", 10)
+        .unwrap()
+        .into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(term),
+        &mut process
+    );
+}
+
+#[test]
+fn with_float_returns_float() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::EMPTY_LIST;
+    let term = Term::EMPTY_LIST;
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(term),
+        &mut process
+    );
+}
+
+#[test]
+fn with_local_pid_returns_local_pid() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::EMPTY_LIST;
+    let term = Term::local_pid(1, 2, &mut process).unwrap();
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(term),
+        &mut process
+    );
+}
+
+#[test]
+fn with_external_pid_returns_external_pid() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::EMPTY_LIST;
+    let term = Term::external_pid(4, 5, 6, &mut process).unwrap();
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(term),
+        &mut process
+    );
+}
+
+#[test]
+fn with_tuple_returns_tuple() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::EMPTY_LIST;
+    let term = Term::slice_to_tuple(&[], &mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(term),
+        &mut process
+    );
+}
+
+#[test]
+fn with_map_is_returns_map_is() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::EMPTY_LIST;
+    let term = Term::slice_to_map(&[], &mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(term),
+        &mut process
+    );
+}
+
+#[test]
+fn with_heap_binary_returns_heap_binary() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let list = Term::EMPTY_LIST;
+    let term = Term::slice_to_binary(&[], &mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(term),
+        &mut process
+    );
+}
+
+#[test]
+fn with_subbinary_returns_subbinary() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let binary_term =
+        Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+    let list = Term::EMPTY_LIST;
+    let term = Term::subbinary(binary_term, 0, 7, 2, 0, &mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(term),
+        &mut process
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/concatenate_2/with_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/concatenate_2/with_list.rs
@@ -1,0 +1,207 @@
+use super::*;
+
+use num_traits::Num;
+
+use std::sync::{Arc, RwLock};
+
+use crate::environment::{self, Environment};
+
+#[test]
+fn with_atom_return_improper_list_with_atom_as_tail() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let element = 0.into_process(&mut process);
+    let list = Term::cons(element, Term::EMPTY_LIST, &mut process);
+    let term = Term::str_to_atom("term", DoNotCare, &mut process).unwrap();
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(Term::cons(element, term, &mut process)),
+        &mut process
+    );
+}
+
+#[test]
+fn with_local_reference_returns_improper_list_with_local_reference_as_tail() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let element = 0.into_process(&mut process);
+    let list = Term::cons(element, Term::EMPTY_LIST, &mut process);
+    let term = Term::local_reference(&mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(Term::cons(element, term, &mut process)),
+        &mut process
+    );
+}
+
+#[test]
+fn with_improper_list_return_improper_list_with_improper_list_as_tail() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let element = 0.into_process(&mut process);
+    let list = Term::cons(element, Term::EMPTY_LIST, &mut process);
+    let term = Term::cons(
+        1.into_process(&mut process),
+        2.into_process(&mut process),
+        &mut process,
+    );
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(Term::cons(element, term, &mut process)),
+        &mut process
+    );
+}
+
+#[test]
+fn with_small_integer_returns_improper_list_with_small_integer_as_tail() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let element = 0.into_process(&mut process);
+    let list = Term::cons(element, Term::EMPTY_LIST, &mut process);
+    let term = 1.into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(Term::cons(element, term, &mut process)),
+        &mut process
+    );
+}
+
+#[test]
+fn with_big_integer_returns_improper_list_with_big_integer_as_tail() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let element = 0.into_process(&mut process);
+    let list = Term::cons(element, Term::EMPTY_LIST, &mut process);
+    let term = <BigInt as Num>::from_str_radix("576460752303423490", 10)
+        .unwrap()
+        .into_process(&mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(Term::cons(element, term, &mut process)),
+        &mut process
+    );
+}
+
+#[test]
+fn with_float_returns_improper_list_with_float_as_tail() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let element = 0.into_process(&mut process);
+    let list = Term::cons(element, Term::EMPTY_LIST, &mut process);
+    let term = Term::cons(0.into_process(&mut process), Term::EMPTY_LIST, &mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(Term::cons(element, term, &mut process)),
+        &mut process
+    );
+}
+
+#[test]
+fn with_local_pid_returns_improper_list_with_local_pid_as_tail() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let element = 0.into_process(&mut process);
+    let list = Term::cons(element, Term::EMPTY_LIST, &mut process);
+    let term = Term::local_pid(1, 2, &mut process).unwrap();
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(Term::cons(element, term, &mut process)),
+        &mut process
+    );
+}
+
+#[test]
+fn with_external_pid_returns_improper_list_with_external_pid_as_tail() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let element = 0.into_process(&mut process);
+    let list = Term::cons(element, Term::EMPTY_LIST, &mut process);
+    let term = Term::external_pid(4, 5, 6, &mut process).unwrap();
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(Term::cons(element, term, &mut process)),
+        &mut process
+    );
+}
+
+#[test]
+fn with_tuple_returns_improper_list_with_tuple_as_tail() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let element = 0.into_process(&mut process);
+    let list = Term::cons(element, Term::EMPTY_LIST, &mut process);
+    let term = Term::slice_to_tuple(&[], &mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(Term::cons(element, term, &mut process)),
+        &mut process
+    );
+}
+
+#[test]
+fn with_map_returns_improper_list_with_map_as_tail() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let element = 0.into_process(&mut process);
+    let list = Term::cons(element, Term::EMPTY_LIST, &mut process);
+    let term = Term::slice_to_map(&[], &mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(Term::cons(element, term, &mut process)),
+        &mut process
+    );
+}
+
+#[test]
+fn with_heap_binary_returns_improper_list_with_heap_binary_as_tail() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let element = 0.into_process(&mut process);
+    let list = Term::cons(element, Term::EMPTY_LIST, &mut process);
+    let term = Term::slice_to_binary(&[], &mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(Term::cons(element, term, &mut process)),
+        &mut process
+    );
+}
+
+#[test]
+fn with_subbinary_returns_improper_list_with_subbinary_as_tail() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let binary_term =
+        Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+    let element = 0.into_process(&mut process);
+    let list = Term::cons(element, Term::EMPTY_LIST, &mut process);
+    let term = Term::subbinary(binary_term, 0, 7, 2, 0, &mut process);
+
+    assert_eq_in_process!(
+        erlang::concatenate_2(list, term, &mut process),
+        Ok(Term::cons(element, term, &mut process)),
+        &mut process
+    );
+}

--- a/lumen_runtime/src/term.rs
+++ b/lumen_runtime/src/term.rs
@@ -1268,8 +1268,9 @@ impl OrderInProcess for Term {
                 Ordering::Less
             }
             (List, SmallInteger) => Ordering::Greater,
+            (List, Atom) => Ordering::Greater,
             (List, EmptyList) => {
-                // Any list is longer than empty lit
+                // Any list is longer than empty list
                 Ordering::Greater
             }
             (List, List) => {


### PR DESCRIPTION
# Changelog
## Enhancements
*  Implement `++/2` as `erlang::concatenate_2` because Rust raw identifiers (`r#`) only work for valid identifiers that would otherwise collide with keywords and `++_2` is not a valid identifier.  @bitwalker is going to handle translation from the Erlang name to Rust name in the compiler.