### PR TITLE
raise/3

### DIFF
--- a/lumen_runtime/src/atom.rs
+++ b/lumen_runtime/src/atom.rs
@@ -130,7 +130,6 @@ impl Atom {
     fn new(name: Arc<String>) -> Self {
         let name = name.clone();
         let ordinal = Self::ordinal(name.as_bytes());
-        println!("ordinal = {:?}", ordinal);
 
         // See https://github.com/erlang/otp/blob/be44d6827e2374a43068b35de85ed16441c771be/erts/emulator/beam/atom.c#L175-L192
         Atom { ordinal, name }

--- a/lumen_runtime/src/lib.rs
+++ b/lumen_runtime/src/lib.rs
@@ -39,6 +39,7 @@ mod logging;
 mod map;
 mod otp;
 mod reference;
+mod stacktrace;
 mod system;
 mod term;
 mod time;

--- a/lumen_runtime/src/list.rs
+++ b/lumen_runtime/src/list.rs
@@ -42,6 +42,13 @@ impl Cons {
         self.into_iter().all(|item| item.is_ok())
     }
 
+    pub fn is_char_list(&self) -> bool {
+        self.into_iter().all(|result| match result {
+            Ok(term) => char::try_from(term).is_ok(),
+            Err(_) => false,
+        })
+    }
+
     pub fn subtract(&self, subtrahend: &Cons, mut process: &mut Process) -> exception::Result {
         match self.into_iter().collect::<Result<Vec<Term>, _>>() {
             Ok(mut self_vec) => {

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -11,13 +11,14 @@ use num_traits::Zero;
 
 use crate::atom::{Existence, Existence::*};
 use crate::binary::{heap, sub, Part, ToTerm, ToTermOptions};
-use crate::exception::Result;
+use crate::exception::{Class, Result};
 use crate::float::Float;
 use crate::integer::{big, small};
 use crate::list::Cons;
 use crate::map::Map;
 use crate::otp;
 use crate::process::{IntoProcess, Process, TryIntoInProcess};
+use crate::stacktrace;
 use crate::term::{Tag, Tag::*, Term};
 use crate::time;
 use crate::tuple::{Tuple, ZeroBasedIndex};
@@ -468,7 +469,7 @@ pub fn insert_element_3(
 }
 
 pub fn is_atom_1(term: Term) -> Term {
-    (term.tag() == Atom).into()
+    term.is_atom().into()
 }
 
 pub fn is_binary_1(term: Term) -> Term {
@@ -674,6 +675,16 @@ pub fn map_size_1(map: Term, mut process: &mut Process) -> Result {
     let map_map: &Map = map.try_into_in_process(&mut process)?;
 
     Ok(map_map.size().into_process(&mut process))
+}
+
+pub fn raise_3(class: Term, reason: Term, stacktrace: Term) -> Result {
+    let class_class: Class = class.try_into()?;
+
+    if stacktrace::is(stacktrace) {
+        Err(raise!(class_class, reason, Some(stacktrace)))
+    } else {
+        Err(bad_argument!())
+    }
 }
 
 pub fn self_0(process: &Process) -> Term {

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -55,6 +55,7 @@ mod list_to_tuple_1;
 mod make_ref_0;
 mod map_get_2;
 mod map_size_1;
+mod raise_3;
 mod self_0;
 mod setelement_3;
 mod size_1;

--- a/lumen_runtime/src/otp/erlang/tests/raise_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/raise_3.rs
@@ -1,0 +1,106 @@
+use super::*;
+
+use num_traits::Num;
+
+//use crate::exception::Class;
+
+mod with_atom_class;
+
+#[test]
+fn with_local_reference_class_errors_badarg() {
+    with_class_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_class_errors_badarg() {
+    with_class_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_class_errors_badarg() {
+    with_class_errors_badarg(|mut process| list_term(&mut process));
+}
+
+#[test]
+fn with_small_integer_class_errors_badarg() {
+    with_class_errors_badarg(|mut process| 0usize.into_process(&mut process));
+}
+
+#[test]
+fn with_big_integer_class_errors_badarg() {
+    with_class_errors_badarg(|mut process| {
+        <BigInt as Num>::from_str_radix("576460752303423489", 10)
+            .unwrap()
+            .into_process(&mut process)
+    });
+}
+
+#[test]
+fn with_float_class_errors_badarg() {
+    with_class_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_class_errors_badarg() {
+    with_class_errors_badarg(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_class_errors_badarg() {
+    with_class_errors_badarg(|mut process| Term::external_pid(1, 0, 0, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_class_errors_badarg() {
+    with_class_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_class_errors_badarg() {
+    with_class_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_class_errors_badarg() {
+    with_class_errors_badarg(|mut process| {
+        // :erlang.term_to_binary(:atom)
+        Term::slice_to_binary(&[131, 100, 0, 4, 97, 116, 111, 109], &mut process)
+    });
+}
+
+#[test]
+fn with_subbinary_class_errors_badarg() {
+    with_class_errors_badarg(|mut process| {
+        // <<1::1, :erlang.term_to_binary(:atom) :: binary>>
+        let original_term = Term::slice_to_binary(
+            &[193, 178, 0, 2, 48, 186, 55, 182, 0b1000_0000],
+            &mut process,
+        );
+        Term::subbinary(original_term, 0, 1, 8, 0, &mut process)
+    });
+}
+
+fn with_class_errors_badarg<C>(class: C)
+where
+    C: FnOnce(&mut Process) -> Term,
+{
+    with_process(|mut process| {
+        let class = class(&mut process);
+        let reason = Term::str_to_atom("reason", DoNotCare).unwrap();
+        let stacktrace = Term::EMPTY_LIST;
+
+        assert_badarg!(erlang::raise_3(class, reason, stacktrace));
+    })
+}
+
+//fn raises<A>(class_reason_stacktrace: A)
+//    where
+//        A: FnOnce(&mut Process) -> ((Term, Class), Term, Term),
+//{
+//    with_process(|mut process| {
+//        let ((class_term, class_class), reason, stacktrace) = class_reason_stacktrace(&mut
+// process);
+//
+//        assert_raises!(erlang::raise_3(class_term, reason, stacktrace), class_class, reason,
+// Some(stacktrace));    })
+//}

--- a/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class.rs
+++ b/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class.rs
@@ -1,0 +1,16 @@
+use super::*;
+
+use crate::exception::Class::*;
+
+mod error;
+mod exit;
+mod throw;
+
+#[test]
+fn with_other_class_errors_badarg() {
+    let class_term = Term::str_to_atom("unsupported_class", DoNotCare).unwrap();
+    let reason = Term::str_to_atom("reason", DoNotCare).unwrap();
+    let stacktrace = Term::EMPTY_LIST;
+
+    assert_badarg!(erlang::raise_3(class_term, reason, stacktrace));
+}

--- a/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/error.rs
+++ b/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/error.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+mod with_list_stacktrace;
+
+#[test]
+fn with_local_reference_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_stacktrace_errors() {
+    let class = Term::str_to_atom("error", DoNotCare).unwrap();
+    let stacktrace = Term::EMPTY_LIST;
+    let reason = Term::str_to_atom("reason", DoNotCare).unwrap();
+
+    assert_raises!(
+        erlang::raise_3(class, reason, stacktrace),
+        Error { arguments: None },
+        reason,
+        Some(stacktrace)
+    );
+}
+
+#[test]
+fn with_small_integer_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| 0usize.into_process(&mut process));
+}
+
+#[test]
+fn with_big_integer_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        <BigInt as Num>::from_str_radix("576460752303423489", 10)
+            .unwrap()
+            .into_process(&mut process)
+    });
+}
+
+#[test]
+fn with_float_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| Term::external_pid(1, 0, 0, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        // :erlang.term_to_binary(:atom)
+        Term::slice_to_binary(&[131, 100, 0, 4, 97, 116, 111, 109], &mut process)
+    });
+}
+
+#[test]
+fn with_subbinary_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        // <<1::1, :erlang.term_to_binary(:atom) :: binary>>
+        let original_term = Term::slice_to_binary(
+            &[193, 178, 0, 2, 48, 186, 55, 182, 0b1000_0000],
+            &mut process,
+        );
+        Term::subbinary(original_term, 0, 1, 8, 0, &mut process)
+    });
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let class = Term::str_to_atom("error", DoNotCare).unwrap();
+        let reason = Term::str_to_atom("reason", DoNotCare).unwrap();
+
+        f(class, reason, &mut process)
+    })
+}
+
+fn with_stacktrace_errors_badarg<S>(stacktrace: S)
+where
+    S: FnOnce(&mut Process) -> Term,
+{
+    with(|class, reason, mut process| {
+        let stacktrace = stacktrace(&mut process);
+
+        assert_badarg!(erlang::raise_3(class, reason, stacktrace))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/error/with_list_stacktrace.rs
+++ b/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/error/with_list_stacktrace.rs
@@ -1,0 +1,363 @@
+use super::*;
+
+#[test]
+fn without_atom_module_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_char_list("module", &mut process),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn without_atom_function_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_char_list("function", &mut process),
+                    0.into_process(&mut process),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn module_function_without_arity_or_arguments_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    Term::str_to_atom("arity", DoNotCare).unwrap(),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_module_function_arity_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_module_function_arguments_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    Term::cons(
+                        Term::str_to_atom("arg1", DoNotCare).unwrap(),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_empty_location_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::EMPTY_LIST,
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_file_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("file", DoNotCare).unwrap(),
+                                Term::str_to_char_list("path_to_file", &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_file_without_char_list_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("file", DoNotCare).unwrap(),
+                                Term::slice_to_binary("path_to_file".as_bytes(), &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_line_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("line", DoNotCare).unwrap(),
+                                1.into_process(&mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_line_with_zero_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("line", DoNotCare).unwrap(),
+                                0.into_process(&mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_line_without_positive_integer_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("line", DoNotCare).unwrap(),
+                                Term::str_to_char_list("first", &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_file_and_line_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("file", DoNotCare).unwrap(),
+                                Term::str_to_char_list("path_to_file", &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::cons(
+                            Term::slice_to_tuple(
+                                &[
+                                    Term::str_to_atom("line", DoNotCare).unwrap(),
+                                    1.into_process(&mut process),
+                                ],
+                                &mut process,
+                            ),
+                            Term::EMPTY_LIST,
+                            &mut process,
+                        ),
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_invalid_location_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("file", DoNotCare).unwrap(),
+                                Term::str_to_char_list("path_to_file", &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::cons(
+                            Term::slice_to_tuple(
+                                &[
+                                    // typo
+                                    Term::str_to_atom("lin", DoNotCare).unwrap(),
+                                    1.into_process(&mut process),
+                                ],
+                                &mut process,
+                            ),
+                            Term::EMPTY_LIST,
+                            &mut process,
+                        ),
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+fn with_stacktrace_raises<S>(stacktrace: S)
+where
+    S: FnOnce(&mut Process) -> Term,
+{
+    with(|class, reason, mut process| {
+        let stacktrace = stacktrace(&mut process);
+
+        assert_raises!(
+            erlang::raise_3(class, reason, stacktrace),
+            Error { arguments: None },
+            reason,
+            Some(stacktrace)
+        )
+    })
+}
+
+fn with_stacktrace_errors_badarg<S>(stacktrace: S)
+where
+    S: FnOnce(&mut Process) -> Term,
+{
+    with(|class, reason, mut process| {
+        assert_badarg!(erlang::raise_3(class, reason, stacktrace(&mut process)))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/exit.rs
+++ b/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/exit.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+mod with_list_stacktrace;
+
+#[test]
+fn with_local_reference_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_stacktrace_errors() {
+    let class = Term::str_to_atom("exit", DoNotCare).unwrap();
+    let stacktrace = Term::EMPTY_LIST;
+    let reason = Term::str_to_atom("reason", DoNotCare).unwrap();
+
+    assert_raises!(
+        erlang::raise_3(class, reason, stacktrace),
+        Exit,
+        reason,
+        Some(stacktrace)
+    );
+}
+
+#[test]
+fn with_small_integer_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| 0usize.into_process(&mut process));
+}
+
+#[test]
+fn with_big_integer_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        <BigInt as Num>::from_str_radix("576460752303423489", 10)
+            .unwrap()
+            .into_process(&mut process)
+    });
+}
+
+#[test]
+fn with_float_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| Term::external_pid(1, 0, 0, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        // :erlang.term_to_binary(:atom)
+        Term::slice_to_binary(&[131, 100, 0, 4, 97, 116, 111, 109], &mut process)
+    });
+}
+
+#[test]
+fn with_subbinary_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        // <<1::1, :erlang.term_to_binary(:atom) :: binary>>
+        let original_term = Term::slice_to_binary(
+            &[193, 178, 0, 2, 48, 186, 55, 182, 0b1000_0000],
+            &mut process,
+        );
+        Term::subbinary(original_term, 0, 1, 8, 0, &mut process)
+    });
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let class = Term::str_to_atom("exit", DoNotCare).unwrap();
+        let reason = Term::str_to_atom("reason", DoNotCare).unwrap();
+
+        f(class, reason, &mut process)
+    })
+}
+
+fn with_stacktrace_errors_badarg<S>(stacktrace: S)
+where
+    S: FnOnce(&mut Process) -> Term,
+{
+    with(|class, reason, mut process| {
+        let stacktrace = stacktrace(&mut process);
+
+        assert_badarg!(erlang::raise_3(class, reason, stacktrace))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/exit/with_list_stacktrace.rs
+++ b/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/exit/with_list_stacktrace.rs
@@ -1,0 +1,363 @@
+use super::*;
+
+#[test]
+fn without_atom_module_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_char_list("module", &mut process),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn without_atom_function_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_char_list("function", &mut process),
+                    0.into_process(&mut process),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn module_function_without_arity_or_arguments_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    Term::str_to_atom("arity", DoNotCare).unwrap(),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_module_function_arity_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_module_function_arguments_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    Term::cons(
+                        Term::str_to_atom("arg1", DoNotCare).unwrap(),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_empty_location_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::EMPTY_LIST,
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_file_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("file", DoNotCare).unwrap(),
+                                Term::str_to_char_list("path_to_file", &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_file_without_char_list_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("file", DoNotCare).unwrap(),
+                                Term::slice_to_binary("path_to_file".as_bytes(), &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_line_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("line", DoNotCare).unwrap(),
+                                1.into_process(&mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_line_with_zero_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("line", DoNotCare).unwrap(),
+                                0.into_process(&mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_line_without_positive_integer_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("line", DoNotCare).unwrap(),
+                                Term::str_to_char_list("first", &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_file_and_line_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("file", DoNotCare).unwrap(),
+                                Term::str_to_char_list("path_to_file", &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::cons(
+                            Term::slice_to_tuple(
+                                &[
+                                    Term::str_to_atom("line", DoNotCare).unwrap(),
+                                    1.into_process(&mut process),
+                                ],
+                                &mut process,
+                            ),
+                            Term::EMPTY_LIST,
+                            &mut process,
+                        ),
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_invalid_location_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("file", DoNotCare).unwrap(),
+                                Term::str_to_char_list("path_to_file", &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::cons(
+                            Term::slice_to_tuple(
+                                &[
+                                    // typo
+                                    Term::str_to_atom("lin", DoNotCare).unwrap(),
+                                    1.into_process(&mut process),
+                                ],
+                                &mut process,
+                            ),
+                            Term::EMPTY_LIST,
+                            &mut process,
+                        ),
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+fn with_stacktrace_raises<S>(stacktrace: S)
+where
+    S: FnOnce(&mut Process) -> Term,
+{
+    with(|class, reason, mut process| {
+        let stacktrace = stacktrace(&mut process);
+
+        assert_raises!(
+            erlang::raise_3(class, reason, stacktrace),
+            Exit,
+            reason,
+            Some(stacktrace)
+        )
+    })
+}
+
+fn with_stacktrace_errors_badarg<S>(stacktrace: S)
+where
+    S: FnOnce(&mut Process) -> Term,
+{
+    with(|class, reason, mut process| {
+        assert_badarg!(erlang::raise_3(class, reason, stacktrace(&mut process)))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/throw.rs
+++ b/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/throw.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+mod with_list_stacktrace;
+
+#[test]
+fn with_local_reference_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_stacktrace_errors() {
+    let class = Term::str_to_atom("error", DoNotCare).unwrap();
+    let stacktrace = Term::EMPTY_LIST;
+    let reason = Term::str_to_atom("reason", DoNotCare).unwrap();
+
+    assert_raises!(
+        erlang::raise_3(class, reason, stacktrace),
+        Error { arguments: None },
+        reason,
+        Some(stacktrace)
+    );
+}
+
+#[test]
+fn with_small_integer_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| 0usize.into_process(&mut process));
+}
+
+#[test]
+fn with_big_integer_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        <BigInt as Num>::from_str_radix("576460752303423489", 10)
+            .unwrap()
+            .into_process(&mut process)
+    });
+}
+
+#[test]
+fn with_float_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| Term::external_pid(1, 0, 0, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        // :erlang.term_to_binary(:atom)
+        Term::slice_to_binary(&[131, 100, 0, 4, 97, 116, 111, 109], &mut process)
+    });
+}
+
+#[test]
+fn with_subbinary_stacktrace_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        // <<1::1, :erlang.term_to_binary(:atom) :: binary>>
+        let original_term = Term::slice_to_binary(
+            &[193, 178, 0, 2, 48, 186, 55, 182, 0b1000_0000],
+            &mut process,
+        );
+        Term::subbinary(original_term, 0, 1, 8, 0, &mut process)
+    });
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let class = Term::str_to_atom("throw", DoNotCare).unwrap();
+        let reason = Term::str_to_atom("reason", DoNotCare).unwrap();
+
+        f(class, reason, &mut process)
+    })
+}
+
+fn with_stacktrace_errors_badarg<S>(stacktrace: S)
+where
+    S: FnOnce(&mut Process) -> Term,
+{
+    with(|class, reason, mut process| {
+        let stacktrace = stacktrace(&mut process);
+
+        assert_badarg!(erlang::raise_3(class, reason, stacktrace))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/throw/with_list_stacktrace.rs
+++ b/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/throw/with_list_stacktrace.rs
@@ -1,0 +1,363 @@
+use super::*;
+
+#[test]
+fn without_atom_module_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_char_list("module", &mut process),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn without_atom_function_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_char_list("function", &mut process),
+                    0.into_process(&mut process),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn module_function_without_arity_or_arguments_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    Term::str_to_atom("arity", DoNotCare).unwrap(),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_module_function_arity_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_module_function_arguments_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    Term::cons(
+                        Term::str_to_atom("arg1", DoNotCare).unwrap(),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_empty_location_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::EMPTY_LIST,
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_file_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("file", DoNotCare).unwrap(),
+                                Term::str_to_char_list("path_to_file", &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_file_without_char_list_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("file", DoNotCare).unwrap(),
+                                Term::slice_to_binary("path_to_file".as_bytes(), &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_line_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("line", DoNotCare).unwrap(),
+                                1.into_process(&mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_line_with_zero_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("line", DoNotCare).unwrap(),
+                                0.into_process(&mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_line_without_positive_integer_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("line", DoNotCare).unwrap(),
+                                Term::str_to_char_list("first", &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::EMPTY_LIST,
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_file_and_line_raises() {
+    with_stacktrace_raises(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("file", DoNotCare).unwrap(),
+                                Term::str_to_char_list("path_to_file", &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::cons(
+                            Term::slice_to_tuple(
+                                &[
+                                    Term::str_to_atom("line", DoNotCare).unwrap(),
+                                    1.into_process(&mut process),
+                                ],
+                                &mut process,
+                            ),
+                            Term::EMPTY_LIST,
+                            &mut process,
+                        ),
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_mfa_with_invalid_location_errors_badarg() {
+    with_stacktrace_errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("module", DoNotCare).unwrap(),
+                    Term::str_to_atom("function", DoNotCare).unwrap(),
+                    0.into_process(&mut process),
+                    Term::cons(
+                        Term::slice_to_tuple(
+                            &[
+                                Term::str_to_atom("file", DoNotCare).unwrap(),
+                                Term::str_to_char_list("path_to_file", &mut process),
+                            ],
+                            &mut process,
+                        ),
+                        Term::cons(
+                            Term::slice_to_tuple(
+                                &[
+                                    // typo
+                                    Term::str_to_atom("lin", DoNotCare).unwrap(),
+                                    1.into_process(&mut process),
+                                ],
+                                &mut process,
+                            ),
+                            Term::EMPTY_LIST,
+                            &mut process,
+                        ),
+                        &mut process,
+                    ),
+                ],
+                &mut process,
+            ),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+fn with_stacktrace_raises<S>(stacktrace: S)
+where
+    S: FnOnce(&mut Process) -> Term,
+{
+    with(|class, reason, mut process| {
+        let stacktrace = stacktrace(&mut process);
+
+        assert_raises!(
+            erlang::raise_3(class, reason, stacktrace),
+            Throw,
+            reason,
+            Some(stacktrace)
+        )
+    })
+}
+
+fn with_stacktrace_errors_badarg<S>(stacktrace: S)
+where
+    S: FnOnce(&mut Process) -> Term,
+{
+    with(|class, reason, mut process| {
+        assert_badarg!(erlang::raise_3(class, reason, stacktrace(&mut process)))
+    })
+}

--- a/lumen_runtime/src/stacktrace.rs
+++ b/lumen_runtime/src/stacktrace.rs
@@ -1,0 +1,175 @@
+use num_bigint::BigInt;
+
+use crate::integer::big;
+use crate::list::Cons;
+use crate::term::{Tag::*, Term};
+use crate::tuple::Tuple;
+
+pub fn is(term: Term) -> bool {
+    match term.tag() {
+        EmptyList => true,
+        List => {
+            let cons: &Cons = unsafe { term.as_ref_cons_unchecked() };
+
+            cons.into_iter().all(|result| match result {
+                Ok(term) => term_is_item(term),
+                Err(_) => false,
+            })
+        }
+        _ => false,
+    }
+}
+
+fn term_is_location(term: Term) -> bool {
+    match term.tag() {
+        EmptyList => true,
+        List => {
+            let cons: &Cons = unsafe { term.as_ref_cons_unchecked() };
+
+            cons.into_iter().all(|result| match result {
+                Ok(term) => term_is_location_keyword_pair(term),
+                Err(_) => false,
+            })
+        }
+        _ => false,
+    }
+}
+
+fn term_is_location_keyword_pair(term: Term) -> bool {
+    match term.tag() {
+        Boxed => {
+            let unboxed: &Term = term.unbox_reference();
+
+            match unboxed.tag() {
+                Arity => {
+                    let tuple: &Tuple = term.unbox_reference();
+
+                    tuple_is_location_keyword_pair(tuple)
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+fn tuple_is_location_keyword_pair(tuple: &Tuple) -> bool {
+    (tuple.len() == 2) & {
+        let first_element = tuple[0];
+
+        match first_element.tag() {
+            Atom => match unsafe { first_element.atom_to_string() }.as_ref().as_ref() {
+                "file" => is_file(tuple[1]),
+                "line" => is_line(tuple[1]),
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+}
+
+fn is_file(term: Term) -> bool {
+    term.is_char_list()
+}
+
+fn is_line(term: Term) -> bool {
+    match term.tag() {
+        SmallInteger => 0 < unsafe { term.small_integer_to_isize() },
+        Boxed => {
+            let unboxed: &Term = term.unbox_reference();
+
+            match unboxed.tag() {
+                BigInteger => {
+                    let big_integer: &big::Integer = term.unbox_reference();
+                    let big_int = &big_integer.inner;
+                    let zero_big_int: &BigInt = &0.into();
+
+                    zero_big_int < big_int
+                }
+                _ => false,
+            }
+        }
+
+        _ => false,
+    }
+}
+
+fn term_is_item(term: Term) -> bool {
+    match term.tag() {
+        Boxed => {
+            let unboxed: &Term = term.unbox_reference();
+
+            match unboxed.tag() {
+                Arity => {
+                    let tuple: &Tuple = term.unbox_reference();
+
+                    tuple_is_item(tuple)
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+fn tuple_is_item(tuple: &Tuple) -> bool {
+    match tuple.len() {
+        // {function, args}
+        // https://github.com/erlang/otp/blob/b51f61b5f32a28737d0b03a29f19f48f38e4db19/erts/emulator/beam/bif.c#L1107-L1114
+        2 => tuple[0].is_function(),
+        // https://github.com/erlang/otp/blob/b51f61b5f32a28737d0b03a29f19f48f38e4db19/erts/emulator/beam/bif.c#L1115-L1128
+        3 => {
+            let first_element = tuple[0];
+
+            match first_element.tag() {
+                // {M, F, arity | args}
+                Atom => tuple[1].is_atom() & is_arity_or_arguments(tuple[2]),
+                // {function, args, location}
+                Boxed => {
+                    let unboxed: &Term = first_element.unbox_reference();
+
+                    (unboxed.tag() == Function) & term_is_location(tuple[2])
+                }
+                _ => false,
+            }
+        }
+        // https://github.com/erlang/otp/blob/b51f61b5f32a28737d0b03a29f19f48f38e4db19/erts/emulator/beam/bif.c#L1129-L1134
+        4 => {
+            // {M, F, arity | args, location}
+            tuple[0].is_atom()
+                & tuple[1].is_atom()
+                & is_arity_or_arguments(tuple[2])
+                & term_is_location(tuple[3])
+        }
+        _ => false,
+    }
+}
+
+fn is_arity_or_arguments(term: Term) -> bool {
+    match term.tag() {
+        // args
+        EmptyList | List => true,
+        // arity
+        SmallInteger => {
+            let arity = unsafe { term.small_integer_to_isize() };
+
+            0 <= arity
+        }
+        // arity
+        Boxed => {
+            let unboxed: &Term = term.unbox_reference();
+
+            match unboxed.tag() {
+                BigInteger => {
+                    let big_integer: &big::Integer = term.unbox_reference();
+                    let big_int = &big_integer.inner;
+                    let zero_big_int: &BigInt = &0.into();
+
+                    zero_big_int <= big_int
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `:erlang.raise/3`
* `lumen_runtime::exception::Exception` now has a `stacktrace: Some(Term)` field for holding the explicit stacktrace passed by `raise/3`.  When it is `None`, the runtime should use the default stacktrace generated by `__STACKTRACE__` from the Erlang stack.