### PR TITLE
Stubbed is_alive/0

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -468,6 +468,11 @@ pub fn insert_element_3(
         .map(|final_inner_tuple| final_inner_tuple.into())
 }
 
+/// Distribution is not supported at this time.  Always returns `false`.
+pub fn is_alive_0() -> Term {
+    false.into()
+}
+
 pub fn is_atom_1(term: Term) -> Term {
     term.is_atom().into()
 }

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -33,6 +33,7 @@ mod error_2;
 mod exit_1;
 mod hd_1;
 mod insert_element_3;
+mod is_alive_0;
 mod is_atom_1;
 mod is_binary_1;
 mod is_boolean_1;

--- a/lumen_runtime/src/otp/erlang/tests/is_alive_0.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_alive_0.rs
@@ -1,0 +1,6 @@
+use super::*;
+
+#[test]
+fn returns_false() {
+    assert_eq!(erlang::is_alive_0(), false.into())
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `:erlang.is_alive/0` stub that always return `false` as we don't support distribution at this time.