### PR TITLE
Stubbed node/0

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -682,6 +682,10 @@ pub fn map_size_1(map: Term, mut process: &mut Process) -> Result {
     Ok(map_map.size().into_process(&mut process))
 }
 
+pub fn node_0() -> Term {
+    Term::str_to_atom("nonode@nohost", DoNotCare).unwrap()
+}
+
 pub fn raise_3(class: Term, reason: Term, stacktrace: Term) -> Result {
     let class_class: Class = class.try_into()?;
 

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -56,6 +56,7 @@ mod list_to_tuple_1;
 mod make_ref_0;
 mod map_get_2;
 mod map_size_1;
+mod node_0;
 mod raise_3;
 mod self_0;
 mod setelement_3;

--- a/lumen_runtime/src/otp/erlang/tests/node_0.rs
+++ b/lumen_runtime/src/otp/erlang/tests/node_0.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+#[test]
+fn returns_nonode_at_nohost() {
+    assert_eq!(
+        erlang::node_0(),
+        Term::str_to_atom("nonode@nohost", DoNotCare).unwrap()
+    )
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `:erlang.node/0` stub that always return `nonode@nohost` as we don't support distribution at this time.