### PR TITLE
//2

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -434,6 +434,21 @@ pub fn delete_element_2(tuple: Term, index: Term, mut process: &mut Process) -> 
         .map(|final_inner_tuple| final_inner_tuple.into())
 }
 
+/// `//2` infix operator.  Unlike `+/2`, `-/2` and `*/2` always promotes to `float` returns the
+/// `float`.
+pub fn divide_2(dividend: Term, divisor: Term, mut process: &mut Process) -> Result {
+    let dividend_f64: f64 = dividend.try_into()?;
+    let divisor_f64: f64 = divisor.try_into()?;
+
+    if divisor_f64 == 0.0 {
+        Err(badarith!())
+    } else {
+        let quotient_f64 = dividend_f64 / divisor_f64;
+
+        Ok(quotient_f64.into_process(&mut process))
+    }
+}
+
 pub fn element_2(tuple: Term, index: Term, mut process: &mut Process) -> Result {
     let inner_tuple: &Tuple = tuple.try_into_in_process(&mut process)?;
     let index_zero_based: ZeroBasedIndex = index.try_into()?;

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -28,6 +28,7 @@ mod ceil_1;
 mod concatenate_2;
 mod convert_time_unit_3;
 mod delete_element_2;
+mod divide_2;
 mod element_2;
 mod error_1;
 mod error_2;

--- a/lumen_runtime/src/otp/erlang/tests/divide_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/divide_2.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+mod with_big_integer_dividend;
+mod with_float_dividend;
+mod with_small_integer_dividend;
+
+#[test]
+fn with_atom_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|_| Term::str_to_atom("dividend", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_local_pid_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| {
+        let original =
+            Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+        Term::subbinary(original, 0, 7, 2, 1, &mut process)
+    });
+}
+
+fn with_dividend_errors_badarith<M>(dividend: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let dividend = dividend(&mut process);
+        let divisor = 0.into_process(&mut process);
+
+        erlang::divide_2(dividend, divisor, &mut process)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/divide_2/with_big_integer_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/divide_2/with_big_integer_dividend.rs
@@ -1,0 +1,180 @@
+use super::*;
+
+#[test]
+fn with_atom_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::str_to_atom("dividend", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_zero_errors_badarith() {
+    with(|dividend, mut process| {
+        let divisor = 0.into_process(&mut process);
+
+        assert_badarith!(erlang::divide_2(dividend, divisor, &mut process))
+    })
+}
+
+#[test]
+fn with_small_integer_divisor_returns_float() {
+    with(|dividend, mut process| {
+        let divisor: Term = 2.into_process(&mut process);
+
+        assert_eq!(divisor.tag(), SmallInteger);
+
+        let result = erlang::divide_2(dividend, divisor, &mut process);
+
+        assert!(result.is_ok());
+
+        let quotient = result.unwrap();
+
+        assert_eq!(quotient.tag(), Boxed);
+
+        let unboxed_quotient: &Term = quotient.unbox_reference();
+
+        assert_eq!(unboxed_quotient.tag(), Float);
+    })
+}
+
+#[test]
+fn with_big_integer_divisor_returns_float() {
+    with(|dividend, mut process| {
+        let divisor = (crate::integer::small::MIN - 1).into_process(&mut process);
+
+        assert_eq!(divisor.tag(), Boxed);
+
+        let unboxed_divisor: &Term = divisor.unbox_reference();
+
+        assert_eq!(unboxed_divisor.tag(), BigInteger);
+
+        let result = erlang::divide_2(dividend, divisor, &mut process);
+
+        assert!(result.is_ok());
+
+        let quotient = result.unwrap();
+
+        assert_eq!(quotient.tag(), Boxed);
+
+        let unboxed_quotient: &Term = quotient.unbox_reference();
+
+        assert_eq!(unboxed_quotient.tag(), Float);
+    })
+}
+
+#[test]
+fn with_float_zero_errors_badarith() {
+    with(|dividend, mut process| {
+        let divisor = 0.0.into_process(&mut process);
+
+        assert_badarith!(erlang::divide_2(dividend, divisor, &mut process))
+    })
+}
+
+#[test]
+fn with_float_divisor_returns_float() {
+    with(|dividend, mut process| {
+        let divisor = 3.0.into_process(&mut process);
+
+        let result = erlang::divide_2(dividend, divisor, &mut process);
+
+        assert!(result.is_ok());
+
+        let quotient = result.unwrap();
+
+        assert_eq!(quotient.tag(), Boxed);
+
+        let unboxed_quotient: &Term = quotient.unbox_reference();
+
+        assert_eq!(unboxed_quotient.tag(), Float);
+    })
+}
+
+#[test]
+fn with_local_pid_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        let original =
+            Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+        Term::subbinary(original, 0, 7, 2, 1, &mut process)
+    });
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let dividend: Term = (crate::integer::small::MAX + 1).into_process(&mut process);
+
+        assert_eq!(dividend.tag(), Boxed);
+
+        let unboxed_dividend: &Term = dividend.unbox_reference();
+
+        assert_eq!(unboxed_dividend.tag(), BigInteger);
+
+        f(dividend, &mut process)
+    })
+}
+
+fn with_divisor_errors_badarith<M>(divisor: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let dividend: Term = (crate::integer::small::MAX + 1).into_process(&mut process);
+
+        assert_eq!(dividend.tag(), Boxed);
+
+        let unboxed_dividend: &Term = dividend.unbox_reference();
+
+        assert_eq!(unboxed_dividend.tag(), BigInteger);
+
+        let divisor = divisor(&mut process);
+
+        erlang::divide_2(dividend, divisor, &mut process)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/divide_2/with_float_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/divide_2/with_float_dividend.rs
@@ -1,0 +1,186 @@
+use super::*;
+
+#[test]
+fn with_atom_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::str_to_atom("dividend", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_zero_errors_badarith() {
+    with(|dividend, mut process| {
+        let divisor = 0.into_process(&mut process);
+
+        assert_badarith!(erlang::divide_2(dividend, divisor, &mut process))
+    })
+}
+
+#[test]
+fn with_small_integer_divisor_returns_float() {
+    with(|dividend, mut process| {
+        let divisor = crate::integer::small::MIN.into_process(&mut process);
+
+        assert_eq!(divisor.tag(), SmallInteger);
+
+        let result = erlang::divide_2(dividend, divisor, &mut process);
+
+        assert!(result.is_ok());
+
+        let quotient = result.unwrap();
+
+        assert_eq!(quotient.tag(), Boxed);
+
+        let unboxed_quotient: &Term = quotient.unbox_reference();
+
+        assert_eq!(unboxed_quotient.tag(), Float);
+    })
+}
+
+#[test]
+fn with_big_integer_divisor_returns_float() {
+    with(|dividend, mut process| {
+        let divisor = (crate::integer::small::MAX + 1).into_process(&mut process);
+
+        assert_eq!(divisor.tag(), Boxed);
+
+        let unboxed_divisor: &Term = divisor.unbox_reference();
+
+        assert_eq!(unboxed_divisor.tag(), BigInteger);
+
+        let result = erlang::divide_2(dividend, divisor, &mut process);
+
+        assert!(result.is_ok());
+
+        let quotient = result.unwrap();
+
+        assert_eq!(quotient.tag(), Boxed);
+
+        let unboxed_quotient: &Term = quotient.unbox_reference();
+
+        assert_eq!(unboxed_quotient.tag(), Float);
+    })
+}
+
+#[test]
+fn with_float_zero_errors_badarith() {
+    with(|dividend, mut process| {
+        let divisor = 0.0.into_process(&mut process);
+
+        assert_badarith!(erlang::divide_2(dividend, divisor, &mut process))
+    })
+}
+
+#[test]
+fn with_float_divisor_without_underflow_or_overflow_returns_float() {
+    with(|dividend, mut process| {
+        let divisor = 4.0.into_process(&mut process);
+
+        assert_eq!(
+            erlang::divide_2(dividend, divisor, &mut process),
+            Ok(0.5.into_process(&mut process))
+        );
+    })
+}
+
+#[test]
+fn with_float_divisor_with_underflow_returns_min_float() {
+    with_process(|mut process| {
+        let dividend = std::f64::MIN.into_process(&mut process);
+        let divisor = 0.1.into_process(&mut process);
+
+        assert_eq!(
+            erlang::divide_2(dividend, divisor, &mut process),
+            Ok(std::f64::MIN.into_process(&mut process))
+        );
+    })
+}
+
+#[test]
+fn with_float_divisor_with_overflow_returns_max_float() {
+    with_process(|mut process| {
+        let dividend = std::f64::MAX.into_process(&mut process);
+        let divisor = 0.1.into_process(&mut process);
+
+        assert_eq!(
+            erlang::divide_2(dividend, divisor, &mut process),
+            Ok(std::f64::MAX.into_process(&mut process))
+        );
+    })
+}
+
+#[test]
+fn with_local_pid_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        let original =
+            Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+        Term::subbinary(original, 0, 7, 2, 1, &mut process)
+    });
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let dividend = 2.0.into_process(&mut process);
+
+        f(dividend, &mut process)
+    })
+}
+
+fn with_divisor_errors_badarith<M>(divisor: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let dividend: Term = 2.0.into_process(&mut process);
+        let divisor = divisor(&mut process);
+
+        erlang::divide_2(dividend, divisor, &mut process)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/divide_2/with_small_integer_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/divide_2/with_small_integer_dividend.rs
@@ -1,0 +1,154 @@
+use super::*;
+
+#[test]
+fn with_atom_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::str_to_atom("dividend", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_zero_errors_badarith() {
+    with(|dividend, mut process| {
+        let divisor = 0.into_process(&mut process);
+
+        assert_badarith!(erlang::divide_2(dividend, divisor, &mut process))
+    })
+}
+
+#[test]
+fn with_small_integer_divisor_returns_float() {
+    with(|dividend, mut process| {
+        let divisor = 4.into_process(&mut process);
+
+        assert_eq!(
+            erlang::divide_2(dividend, divisor, &mut process),
+            Ok(0.5.into_process(&mut process))
+        );
+    })
+}
+
+#[test]
+fn with_big_integer_divisor_returns_float() {
+    with(|dividend, mut process| {
+        let divisor = (crate::integer::small::MIN - 1).into_process(&mut process);
+
+        assert_eq!(divisor.tag(), Boxed);
+
+        let unboxed_divisor: &Term = divisor.unbox_reference();
+
+        assert_eq!(unboxed_divisor.tag(), BigInteger);
+
+        let result = erlang::divide_2(dividend, divisor, &mut process);
+
+        assert!(result.is_ok());
+
+        let quotient = result.unwrap();
+
+        assert_eq!(quotient.tag(), Boxed);
+
+        let unboxed_quotient: &Term = quotient.unbox_reference();
+
+        assert_eq!(unboxed_quotient.tag(), Float);
+    })
+}
+
+#[test]
+fn with_float_zero_errors_badarith() {
+    with(|dividend, mut process| {
+        let divisor = 0.0.into_process(&mut process);
+
+        assert_badarith!(erlang::divide_2(dividend, divisor, &mut process))
+    })
+}
+
+#[test]
+fn with_float_divisor_returns_float() {
+    with(|dividend, mut process| {
+        let divisor = 4.0.into_process(&mut process);
+
+        assert_eq!(
+            erlang::divide_2(dividend, divisor, &mut process),
+            Ok(0.5.into_process(&mut process))
+        );
+    })
+}
+
+#[test]
+fn with_local_pid_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        let original =
+            Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+        Term::subbinary(original, 0, 7, 2, 1, &mut process)
+    });
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let dividend = 2.into_process(&mut process);
+
+        f(dividend, &mut process)
+    })
+}
+
+fn with_divisor_errors_badarith<M>(divisor: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let dividend: Term = 2.into_process(&mut process);
+
+        assert_eq!(dividend.tag(), SmallInteger);
+
+        let divisor = divisor(&mut process);
+
+        erlang::divide_2(dividend, divisor, &mut process)
+    });
+}

--- a/lumen_runtime/src/term.rs
+++ b/lumen_runtime/src/term.rs
@@ -1195,6 +1195,40 @@ impl TryFrom<Term> for char {
     }
 }
 
+impl TryFrom<Term> for f64 {
+    type Error = Exception;
+
+    fn try_from(term: Term) -> Result<f64, Exception> {
+        match term.tag() {
+            SmallInteger => {
+                let term_isize: isize = unsafe { term.small_integer_to_isize() };
+                let term_f64: f64 = term_isize as f64;
+
+                Ok(term_f64)
+            }
+            Boxed => {
+                let unboxed: &Term = term.unbox_reference();
+
+                match unboxed.tag() {
+                    BigInteger => {
+                        let big_integer: &big::Integer = term.unbox_reference();
+                        let term_f64: f64 = big_integer.into();
+
+                        Ok(term_f64)
+                    }
+                    Float => {
+                        let float: &Float = term.unbox_reference();
+
+                        Ok(float.inner)
+                    }
+                    _ => Err(badarith!()),
+                }
+            }
+            _ => Err(badarith!()),
+        }
+    }
+}
+
 impl TryFrom<Term> for isize {
     type Error = Exception;
 


### PR DESCRIPTION
# Changelog
## Enhancements
* `//2` implemented as `divide/2`.  Covers all numbers (small integers, big integers, and floats).  Unlike `+/2`, `-/2`, and `*/2`, which follow the same promotion rules and keep integers as integers when possible, `//2` always converts to floats.