### PR TITLE
div/2

### DIFF
--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -28,6 +28,7 @@ mod ceil_1;
 mod concatenate_2;
 mod convert_time_unit_3;
 mod delete_element_2;
+mod div_2;
 mod divide_2;
 mod element_2;
 mod error_1;

--- a/lumen_runtime/src/otp/erlang/tests/div_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/div_2.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+mod with_big_integer_dividend;
+mod with_float_dividend;
+mod with_small_integer_dividend;
+
+#[test]
+fn with_atom_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|_| Term::str_to_atom("dividend", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_local_pid_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_dividend_errors_badarith() {
+    with_dividend_errors_badarith(|mut process| {
+        let original =
+            Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+        Term::subbinary(original, 0, 7, 2, 1, &mut process)
+    });
+}
+
+fn with_dividend_errors_badarith<M>(dividend: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let dividend = dividend(&mut process);
+        let divisor = 0.into_process(&mut process);
+
+        erlang::div_2(dividend, divisor, &mut process)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/div_2/with_big_integer_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/div_2/with_big_integer_dividend.rs
@@ -1,0 +1,187 @@
+use super::*;
+
+#[test]
+fn with_atom_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::str_to_atom("dividend", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_zero_errors_badarith() {
+    with(|dividend, mut process| {
+        let divisor = 0.into_process(&mut process);
+
+        assert_badarith!(erlang::div_2(dividend, divisor, &mut process))
+    })
+}
+
+#[test]
+fn with_small_integer_divisor_with_underflow_returns_small_integer() {
+    with(|dividend, mut process| {
+        let divisor: Term = 2.into_process(&mut process);
+
+        assert_eq!(divisor.tag(), SmallInteger);
+
+        let result = erlang::div_2(dividend, divisor, &mut process);
+
+        assert!(result.is_ok());
+
+        let quotient = result.unwrap();
+
+        assert_eq!(quotient.tag(), SmallInteger);
+    })
+}
+
+#[test]
+fn with_big_integer_divisor_with_underflow_returns_small_integer() {
+    with(|dividend, mut process| {
+        let divisor = dividend;
+
+        assert_eq!(divisor.tag(), Boxed);
+
+        let unboxed_divisor: &Term = divisor.unbox_reference();
+
+        assert_eq!(unboxed_divisor.tag(), BigInteger);
+
+        let result = erlang::div_2(dividend, divisor, &mut process);
+
+        assert!(result.is_ok());
+
+        let quotient = result.unwrap();
+
+        assert_eq!(quotient.tag(), SmallInteger);
+        assert_eq!(quotient, 1.into_process(&mut process))
+    })
+}
+
+#[test]
+fn with_big_integer_divisor_without_underflow_returns_big_integer() {
+    with_process(|mut process| {
+        let divisor: Term = (crate::integer::small::MAX + 1).into_process(&mut process);
+
+        assert_eq!(divisor.tag(), Boxed);
+
+        let unboxed_divisor: &Term = divisor.unbox_reference();
+
+        assert_eq!(unboxed_divisor.tag(), BigInteger);
+
+        let dividend = erlang::multiply_2(divisor, divisor, &mut process).unwrap();
+
+        let result = erlang::div_2(dividend, divisor, &mut process);
+
+        assert!(result.is_ok());
+
+        let quotient = result.unwrap();
+
+        assert_eq!(quotient.tag(), Boxed);
+
+        let unboxed_quotient: &Term = quotient.unbox_reference();
+
+        assert_eq!(unboxed_quotient.tag(), BigInteger);
+        assert_eq!(quotient, divisor);
+    })
+}
+
+#[test]
+fn with_float_zero_errors_badarith() {
+    with(|dividend, mut process| {
+        let divisor = 0.0.into_process(&mut process);
+
+        assert_badarith!(erlang::div_2(dividend, divisor, &mut process))
+    })
+}
+
+#[test]
+fn with_float_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| 3.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        let original =
+            Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+        Term::subbinary(original, 0, 7, 2, 1, &mut process)
+    });
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let dividend: Term = (crate::integer::small::MAX + 1).into_process(&mut process);
+
+        assert_eq!(dividend.tag(), Boxed);
+
+        let unboxed_dividend: &Term = dividend.unbox_reference();
+
+        assert_eq!(unboxed_dividend.tag(), BigInteger);
+
+        f(dividend, &mut process)
+    })
+}
+
+fn with_divisor_errors_badarith<M>(divisor: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let dividend: Term = (crate::integer::small::MAX + 1).into_process(&mut process);
+
+        assert_eq!(dividend.tag(), Boxed);
+
+        let unboxed_dividend: &Term = dividend.unbox_reference();
+
+        assert_eq!(unboxed_dividend.tag(), BigInteger);
+
+        let divisor = divisor(&mut process);
+
+        erlang::div_2(dividend, divisor, &mut process)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/div_2/with_float_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/div_2/with_float_dividend.rs
@@ -1,0 +1,97 @@
+use super::*;
+
+#[test]
+fn with_atom_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::str_to_atom("dividend", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_zero_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| 0.into_process(&mut process));
+}
+
+#[test]
+fn with_small_integer_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        crate::integer::small::MIN.into_process(&mut process)
+    });
+}
+
+#[test]
+fn with_big_integer_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        (crate::integer::small::MAX + 1).into_process(&mut process)
+    });
+}
+
+#[test]
+fn with_float_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| 4.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        let original =
+            Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+        Term::subbinary(original, 0, 7, 2, 1, &mut process)
+    });
+}
+
+fn with_divisor_errors_badarith<M>(divisor: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let dividend: Term = 2.0.into_process(&mut process);
+        let divisor = divisor(&mut process);
+
+        erlang::div_2(dividend, divisor, &mut process)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/div_2/with_small_integer_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/div_2/with_small_integer_dividend.rs
@@ -1,0 +1,127 @@
+use super::*;
+
+#[test]
+fn with_atom_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::str_to_atom("dividend", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_zero_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| 0.into_process(&mut process))
+}
+
+#[test]
+fn with_small_integer_divisor_returns_small_integer() {
+    with(|dividend, mut process| {
+        let divisor = 2.into_process(&mut process);
+
+        assert_eq!(
+            erlang::div_2(dividend, divisor, &mut process),
+            Ok(6.into_process(&mut process))
+        );
+    })
+}
+
+#[test]
+fn with_big_integer_divisor_returns_zero() {
+    with(|dividend, mut process| {
+        let divisor = (crate::integer::small::MIN - 1).into_process(&mut process);
+
+        assert_eq!(divisor.tag(), Boxed);
+
+        let unboxed_divisor: &Term = divisor.unbox_reference();
+
+        assert_eq!(unboxed_divisor.tag(), BigInteger);
+
+        assert_eq!(
+            erlang::div_2(dividend, divisor, &mut process),
+            Ok(0.into_process(&mut process))
+        );
+    })
+}
+
+#[test]
+fn with_float_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| 4.0.into_process(&mut process))
+}
+
+#[test]
+fn with_local_pid_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_divisor_errors_badarith() {
+    with_divisor_errors_badarith(|mut process| {
+        let original =
+            Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+        Term::subbinary(original, 0, 7, 2, 1, &mut process)
+    });
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let dividend = 12.into_process(&mut process);
+
+        f(dividend, &mut process)
+    })
+}
+
+fn with_divisor_errors_badarith<M>(divisor: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let dividend: Term = 12.into_process(&mut process);
+
+        assert_eq!(dividend.tag(), SmallInteger);
+
+        let divisor = divisor(&mut process);
+
+        erlang::div_2(dividend, divisor, &mut process)
+    });
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `div/2` infix operator.  Integer division.  Errors with `:badarith` instead of `:badarg`.