### PR TITLE
+/1

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -591,19 +591,7 @@ pub fn is_map_key_2(key: Term, map: Term, mut process: &mut Process) -> Result {
 }
 
 pub fn is_number_1(term: Term) -> Term {
-    match term.tag() {
-        SmallInteger => true,
-        Boxed => {
-            let unboxed: &Term = term.unbox_reference();
-
-            match unboxed.tag() {
-                BigInteger | Float => true,
-                _ => false,
-            }
-        }
-        _ => false,
-    }
-    .into()
+    term.is_number().into()
 }
 
 pub fn is_pid_1(term: Term) -> Term {
@@ -714,6 +702,15 @@ pub fn multiply_2(multiplier: Term, multiplicand: Term, mut process: &mut Proces
 
 pub fn node_0() -> Term {
     Term::str_to_atom("nonode@nohost", DoNotCare).unwrap()
+}
+
+/// `+/1` prefix operator.
+pub fn number_or_badarith_1(term: Term) -> Result {
+    if term.is_number() {
+        Ok(term)
+    } else {
+        Err(badarith!())
+    }
 }
 
 pub fn raise_3(class: Term, reason: Term, stacktrace: Term) -> Result {

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -61,6 +61,7 @@ mod map_get_2;
 mod map_size_1;
 mod multiply_2;
 mod node_0;
+mod number_or_badarith_1;
 mod raise_3;
 mod rem_2;
 mod self_0;

--- a/lumen_runtime/src/otp/erlang/tests/number_or_badarith_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/number_or_badarith_1.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+use num_traits::Num;
+
+use crate::process::IntoProcess;
+
+#[test]
+fn with_atom_errors_badarith() {
+    errors_badarith(|_| Term::str_to_atom("number", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_errors_badarith() {
+    errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_errors_badarith() {
+    errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_errors_badarith() {
+    errors_badarith(|mut process| list_term(&mut process));
+}
+
+#[test]
+fn with_small_integer_returns_argument() {
+    returns_term(|mut process| 0usize.into_process(&mut process));
+}
+
+#[test]
+fn with_big_integer_returns_argument() {
+    returns_term(|mut process| {
+        <BigInt as Num>::from_str_radix("576460752303423489", 10)
+            .unwrap()
+            .into_process(&mut process)
+    });
+}
+
+#[test]
+fn with_float_returns_argument() {
+    returns_term(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_errors_badarith() {
+    errors_badarith(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_errors_badarith() {
+    errors_badarith(|mut process| Term::external_pid(1, 0, 0, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_errors_badarith() {
+    errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_errors_badarith() {
+    errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_errors_badarith() {
+    errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_errors_badarith() {
+    errors_badarith(|mut process| {
+        let original =
+            Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+        Term::subbinary(original, 0, 7, 2, 1, &mut process)
+    });
+}
+
+fn errors_badarith<T>(term: T)
+where
+    T: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| erlang::number_or_badarith_1(term(&mut process)));
+}
+
+fn returns_term<T>(term: T)
+where
+    T: FnOnce(&mut Process) -> Term,
+{
+    with_process(|mut process| {
+        let term = term(&mut process);
+
+        assert_eq!(erlang::number_or_badarith_1(term), Ok(term))
+    })
+}

--- a/lumen_runtime/src/term.rs
+++ b/lumen_runtime/src/term.rs
@@ -353,6 +353,21 @@ impl Term {
         }
     }
 
+    pub fn is_number(&self) -> bool {
+        match self.tag() {
+            SmallInteger => true,
+            Boxed => {
+                let unboxed: &Term = self.unbox_reference();
+
+                match unboxed.tag() {
+                    BigInteger | Float => true,
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
     pub fn pid(
         node: usize,
         number: usize,


### PR DESCRIPTION
# Changelog
## Enhancements
* Implemented as `number_or_badarith/1`.  Returns the argument if it is a number (small integer, big integer, or float); otherwise, errors `:badarith`.