### PR TITLE
-/1

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -700,6 +700,38 @@ pub fn multiply_2(multiplier: Term, multiplicand: Term, mut process: &mut Proces
     number_infix_operator!(multiplier, multiplicand, process, checked_mul, *)
 }
 
+/// `-/1` prefix operator.
+pub fn negate_1(number: Term, mut process: &mut Process) -> Result {
+    match number.tag() {
+        SmallInteger => {
+            let number_isize = unsafe { number.small_integer_to_isize() };
+            let negated_isize = -number_isize;
+
+            Ok(negated_isize.into_process(&mut process))
+        }
+        Boxed => {
+            let unboxed: &Term = number.unbox_reference();
+
+            match unboxed.tag() {
+                BigInteger => {
+                    let big_integer: &big::Integer = number.unbox_reference();
+                    let negated_big_int = -&big_integer.inner;
+
+                    Ok(negated_big_int.into_process(&mut process))
+                }
+                Float => {
+                    let float: &Float = number.unbox_reference();
+                    let negated_f64 = -float.inner;
+
+                    Ok(negated_f64.into_process(&mut process))
+                }
+                _ => Err(badarith!()),
+            }
+        }
+        _ => Err(badarith!()),
+    }
+}
+
 pub fn node_0() -> Term {
     Term::str_to_atom("nonode@nohost", DoNotCare).unwrap()
 }

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -60,6 +60,7 @@ mod make_ref_0;
 mod map_get_2;
 mod map_size_1;
 mod multiply_2;
+mod negate_1;
 mod node_0;
 mod number_or_badarith_1;
 mod raise_3;

--- a/lumen_runtime/src/otp/erlang/tests/negate_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/negate_1.rs
@@ -1,0 +1,97 @@
+use super::*;
+
+use crate::process::IntoProcess;
+
+#[test]
+fn with_atom_errors_badarith() {
+    errors_badarith(|_| Term::str_to_atom("number", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_errors_badarith() {
+    errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_errors_badarith() {
+    errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_errors_badarith() {
+    errors_badarith(|mut process| list_term(&mut process));
+}
+
+#[test]
+fn with_small_integer_returns_small_integer() {
+    with_process(|mut process| {
+        assert_eq!(
+            erlang::negate_1(1.into_process(&mut process), &mut process),
+            Ok((-1_isize).into_process(&mut process))
+        );
+    });
+}
+
+#[test]
+fn with_big_integer_returns_big_integer() {
+    with_process(|mut process| {
+        assert_eq!(
+            erlang::negate_1(
+                (crate::integer::small::MIN - 1).into_process(&mut process),
+                &mut process
+            ),
+            Ok((crate::integer::small::MAX + 2).into_process(&mut process))
+        );
+    });
+}
+
+#[test]
+fn with_float_returns_argument() {
+    with_process(|mut process| {
+        assert_eq!(
+            erlang::negate_1((-1.0).into_process(&mut process), &mut process),
+            Ok(1.0.into_process(&mut process))
+        );
+    });
+}
+
+#[test]
+fn with_local_pid_errors_badarith() {
+    errors_badarith(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_errors_badarith() {
+    errors_badarith(|mut process| Term::external_pid(1, 0, 0, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_errors_badarith() {
+    errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_errors_badarith() {
+    errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_errors_badarith() {
+    errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_errors_badarith() {
+    errors_badarith(|mut process| {
+        let original =
+            Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+        Term::subbinary(original, 0, 7, 2, 1, &mut process)
+    });
+}
+
+fn errors_badarith<N>(number: N)
+where
+    N: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| erlang::negate_1(number(&mut process), &mut process));
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `-/1` implemented as `negate/1`.  Returns numbers (small integer, big integer, or float) negated; otherwise, errors `:badarith`.