### PR TITLE
list_to_binary/1

### DIFF
--- a/lumen_runtime/src/binary/heap.rs
+++ b/lumen_runtime/src/binary/heap.rs
@@ -38,6 +38,10 @@ impl Binary {
         }
     }
 
+    pub fn as_slice(&self) -> &'static [u8] {
+        unsafe { std::slice::from_raw_parts(self.bytes, self.header.heap_binary_to_byte_count()) }
+    }
+
     pub fn bit_len(&self) -> usize {
         self.byte_len() * 8
     }
@@ -85,9 +89,7 @@ impl Binary {
     }
 
     pub fn to_atom_index(&self, existence: Existence) -> Option<atom::Index> {
-        let bytes = unsafe {
-            std::slice::from_raw_parts(self.bytes, Term::heap_binary_to_byte_count(&self.header))
-        };
+        let bytes = self.as_slice();
 
         atom::str_to_index(std::str::from_utf8(bytes).unwrap(), existence)
     }

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -55,6 +55,7 @@ mod is_reference_1;
 mod is_tuple_1;
 mod length_1;
 mod list_to_atom_1;
+mod list_to_binary_1;
 mod list_to_existing_atom_1;
 mod list_to_pid_1;
 mod list_to_tuple_1;

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1.rs
@@ -1,0 +1,129 @@
+use super::*;
+
+use std::sync::{Arc, RwLock};
+
+use crate::environment::{self, Environment};
+
+mod with_list;
+
+#[test]
+fn with_atom_errors_badarg() {
+    errors_badarg(|_| Term::str_to_atom("iolist", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_errors_badarg() {
+    errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_returns_empty_binary() {
+    with_process(|mut process| {
+        assert_eq!(
+            erlang::list_to_binary_1(Term::EMPTY_LIST, &mut process),
+            Ok(Term::slice_to_binary(&[], &mut process))
+        );
+    });
+}
+
+#[test]
+fn with_small_integer_errors_badarg() {
+    errors_badarg(|mut process| 0.into_process(&mut process));
+}
+
+#[test]
+fn with_big_integer_errors_badarg() {
+    errors_badarg(|mut process| (crate::integer::small::MAX + 1).into_process(&mut process));
+}
+
+#[test]
+fn with_float_errors_badarg() {
+    errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_errors_badarg() {
+    errors_badarg(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_errors_badarg() {
+    errors_badarg(|mut process| Term::external_pid(1, 0, 0, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_errors_badarg() {
+    errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_errors_badarg() {
+    errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_errors_badarg() {
+    errors_badarg(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+// > Bin1 = <<1,2,3>>.
+// <<1,2,3>>
+// > Bin2 = <<4,5>>.
+// <<4,5>>
+// > Bin3 = <<6>>.
+// <<6>>
+// > list_to_binary([Bin1,1,[2,3,Bin2],4|Bin3]).
+// <<1,2,3,1,2,3,4,5,4,6>>
+#[test]
+fn otp_doctest_returns_binary() {
+    with_process(|mut process| {
+        let bin1 = Term::slice_to_binary(&[1, 2, 3], &mut process);
+        let bin2 = Term::slice_to_binary(&[4, 5], &mut process);
+        let bin3 = Term::slice_to_binary(&[6], &mut process);
+
+        let iolist = Term::slice_to_improper_list(
+            &[
+                bin1,
+                1.into_process(&mut process),
+                Term::slice_to_list(
+                    &[
+                        2.into_process(&mut process),
+                        3.into_process(&mut process),
+                        bin2,
+                    ],
+                    &mut process,
+                ),
+                4.into_process(&mut process),
+            ],
+            bin3,
+            &mut process,
+        );
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(
+                &[1, 2, 3, 1, 2, 3, 4, 5, 4, 6],
+                &mut process
+            ))
+        )
+    });
+}
+
+#[test]
+fn with_subbinary_errors_badarg() {
+    let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
+    let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
+    let mut process = process_rw_lock.write().unwrap();
+    let binary_term =
+        Term::slice_to_binary(&[0b0000_00001, 0b1111_1110, 0b1010_1011], &mut process);
+    let subbinary_term = Term::subbinary(binary_term, 0, 7, 2, 1, &mut process);
+
+    assert_badarg!(erlang::list_to_binary_1(subbinary_term, &mut process));
+}
+
+fn errors_badarg<I>(iolist: I)
+where
+    I: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarg(|mut process| erlang::list_to_binary_1(iolist(&mut process), &mut process))
+}

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list.rs
@@ -1,0 +1,145 @@
+use super::*;
+
+mod with_binary_subbinary;
+mod with_byte;
+mod with_heap_binary;
+
+#[test]
+fn with_atom_errors_badarg() {
+    errors_badarg(|mut process| {
+        Term::cons(
+            Term::str_to_atom("", DoNotCare).unwrap(),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_local_reference_errors_badarg() {
+    errors_badarg(|mut process| {
+        Term::cons(
+            Term::local_reference(&mut process),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_empty_list_returns_empty_binary() {
+    with_process(|mut process| {
+        let iolist = Term::cons(Term::EMPTY_LIST, Term::EMPTY_LIST, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[], &mut process))
+        );
+    })
+}
+
+#[test]
+fn with_small_integer_with_byte_overflow_errors_badarg() {
+    errors_badarg(|mut process| {
+        Term::cons(
+            256.into_process(&mut process),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_big_integer_errors_badarg() {
+    errors_badarg(|mut process| {
+        Term::cons(
+            (crate::integer::small::MAX + 1).into_process(&mut process),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_float_errors_badarg() {
+    errors_badarg(|mut process| {
+        Term::cons(
+            1.0.into_process(&mut process),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_local_pid_errors_badarg() {
+    errors_badarg(|mut process| {
+        Term::cons(
+            Term::local_pid(0, 0).unwrap(),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_external_pid_errors_badarg() {
+    errors_badarg(|mut process| {
+        Term::cons(
+            Term::external_pid(1, 0, 0, &mut process).unwrap(),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_tuple_errors_badarg() {
+    errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_tuple(&[], &mut process),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_map_errors_badarg() {
+    errors_badarg(|mut process| {
+        Term::cons(
+            Term::slice_to_map(&[], &mut process),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}
+
+#[test]
+fn with_subbinary_without_bit_count_returns_binary_containing_subbinary_bytes() {
+    with_process(|mut process| {
+        let original = Term::slice_to_binary(&[0b0111_1111, 0b1000_0000], &mut process);
+        let iolist = Term::cons(
+            Term::subbinary(original, 0, 1, 1, 0, &mut process),
+            Term::EMPTY_LIST,
+            &mut process,
+        );
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[0b1111_1111], &mut process))
+        );
+    });
+}
+
+#[test]
+fn with_subbinary_with_bit_count_errors_badarg() {
+    errors_badarg(|mut process| {
+        let original = Term::slice_to_binary(&[0b0111_1111, 0b1100_0000], &mut process);
+        Term::cons(
+            Term::subbinary(original, 0, 1, 1, 1, &mut process),
+            Term::EMPTY_LIST,
+            &mut process,
+        )
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_binary_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_binary_subbinary.rs
@@ -1,0 +1,158 @@
+use super::*;
+
+#[test]
+fn with_atom_errors_badarg() {
+    with_tail_errors_badarg(|_| Term::str_to_atom("", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_errors_badarg() {
+    with_tail_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_returns_binary() {
+    with(|head, mut process| {
+        let tail = Term::EMPTY_LIST;
+        let iolist = Term::cons(head, tail, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[255], &mut process))
+        );
+    })
+}
+
+#[test]
+fn with_list_with_byte_tail_errors_badarg() {
+    with_tail_errors_badarg(|mut process| {
+        let tail_head_byte = 254;
+        let tail_head = tail_head_byte.into_process(&mut process);
+
+        let tail_tail_byte = 253;
+        let tail_tail = tail_tail_byte.into_process(&mut process);
+
+        Term::cons(tail_head, tail_tail, &mut process)
+    });
+}
+
+#[test]
+fn with_list_without_byte_tail_returns_binary() {
+    with(|head, mut process| {
+        let tail_head_byte = 254;
+        let tail_head = tail_head_byte.into_process(&mut process);
+
+        let tail_tail = Term::EMPTY_LIST;
+
+        let tail = Term::cons(tail_head, tail_tail, &mut process);
+
+        let iolist = Term::cons(head, tail, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[255, 254], &mut process))
+        );
+    })
+}
+
+#[test]
+fn with_byte_returns_errors_badarg() {
+    with_tail_errors_badarg(|mut process| 254.into_process(&mut process));
+}
+
+#[test]
+fn with_small_integer_with_byte_overflow_errors_badarg() {
+    with_tail_errors_badarg(|mut process| 256.into_process(&mut process));
+}
+
+#[test]
+fn with_big_integer_errors_badarg() {
+    with_tail_errors_badarg(|mut process| {
+        (crate::integer::small::MAX + 1).into_process(&mut process)
+    });
+}
+
+#[test]
+fn with_float_errors_badarg() {
+    with_tail_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_errors_badarg() {
+    with_tail_errors_badarg(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_errors_badarg() {
+    with_tail_errors_badarg(|mut process| Term::external_pid(1, 0, 0, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_errors_badarg() {
+    with_tail_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_errors_badarg() {
+    with_tail_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_returns_binary() {
+    with(|head, mut process| {
+        let tail = Term::slice_to_binary(&[254, 253], &mut process);
+
+        let iolist = Term::cons(head, tail, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[255, 254, 253], &mut process))
+        );
+    })
+}
+
+#[test]
+fn with_subbinary_without_bitcount_returns_binary() {
+    with(|head, mut process| {
+        let original = Term::slice_to_binary(&[0b0111_1111, 0b0000_0000], &mut process);
+        let tail = Term::subbinary(original, 0, 1, 1, 0, &mut process);
+
+        let iolist = Term::cons(head, tail, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[255, 254], &mut process))
+        );
+    })
+}
+
+#[test]
+fn with_subbinary_with_bitcount_errors_badarg() {
+    with_tail_errors_badarg(|mut process| {
+        let original = Term::slice_to_binary(&[0b0111_1111, 0b1100_0000], &mut process);
+        Term::subbinary(original, 0, 1, 1, 1, &mut process)
+    })
+}
+
+fn with_tail_errors_badarg<T>(tail: T)
+where
+    T: FnOnce(&mut Process) -> Term,
+{
+    with(|head, mut process| {
+        let iolist = Term::cons(head, tail(&mut process), &mut process);
+
+        assert_badarg!(erlang::list_to_binary_1(iolist, &mut process));
+    });
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let original = Term::slice_to_binary(&[0b0111_1111, 0b1000_0000], &mut process);
+        let head = Term::subbinary(original, 0, 1, 1, 0, &mut process);
+
+        f(head, &mut process);
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_byte.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_byte.rs
@@ -1,0 +1,161 @@
+use super::*;
+
+#[test]
+fn with_atom_errors_badarg() {
+    with_tail_errors_badarg(|_| Term::str_to_atom("", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_errors_badarg() {
+    with_tail_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_returns_1_byte_binary() {
+    with(|head_byte, head, mut process| {
+        let tail = Term::EMPTY_LIST;
+        let iolist = Term::cons(head, tail, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[head_byte], &mut process))
+        );
+    })
+}
+
+#[test]
+fn with_list_with_byte_tail_errors_badarg() {
+    with_tail_errors_badarg(|mut process| {
+        let tail_head_byte = 1;
+        let tail_head = tail_head_byte.into_process(&mut process);
+
+        let tail_tail_byte = 2;
+        let tail_tail = tail_tail_byte.into_process(&mut process);
+
+        Term::cons(tail_head, tail_tail, &mut process)
+    })
+}
+
+#[test]
+fn with_list_without_byte_tail_returns_binary() {
+    with(|head_byte, head, mut process| {
+        let tail_head_byte = 254;
+        let tail_head = tail_head_byte.into_process(&mut process);
+
+        let tail_tail = Term::EMPTY_LIST;
+
+        let tail = Term::cons(tail_head, tail_tail, &mut process);
+
+        let iolist = Term::cons(head, tail, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(
+                &[head_byte, tail_head_byte],
+                &mut process
+            ))
+        );
+    })
+}
+
+#[test]
+fn with_byte_errors_badarg() {
+    with_tail_errors_badarg(|mut process| 1.into_process(&mut process));
+}
+
+#[test]
+fn with_small_integer_with_byte_overflow_errors_badarg() {
+    with_tail_errors_badarg(|mut process| 256.into_process(&mut process));
+}
+
+#[test]
+fn with_big_integer_errors_badarg() {
+    with_tail_errors_badarg(|mut process| {
+        (crate::integer::small::MAX + 1).into_process(&mut process)
+    });
+}
+
+#[test]
+fn with_float_errors_badarg() {
+    with_tail_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_errors_badarg() {
+    with_tail_errors_badarg(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_errors_badarg() {
+    with_tail_errors_badarg(|mut process| Term::external_pid(1, 0, 0, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_errors_badarg() {
+    with_tail_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_errors_badarg() {
+    with_tail_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_returns_binary() {
+    with(|head_byte, head, mut process| {
+        let tail = Term::slice_to_binary(&[1, 2], &mut process);
+
+        let iolist = Term::cons(head, tail, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[head_byte, 1, 2], &mut process))
+        );
+    })
+}
+
+#[test]
+fn with_subbinary_without_bitcount_returns_binary() {
+    with(|head_byte, head, mut process| {
+        let original = Term::slice_to_binary(&[0b0111_1111, 0b1000_0000], &mut process);
+        let tail = Term::subbinary(original, 0, 1, 1, 0, &mut process);
+
+        let iolist = Term::cons(head, tail, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[head_byte, 255], &mut process))
+        );
+    })
+}
+
+#[test]
+fn with_subbinary_with_bitcount_errors_badarg() {
+    with_tail_errors_badarg(|mut process| {
+        let original = Term::slice_to_binary(&[0b0111_1111, 0b1100_0000], &mut process);
+        Term::subbinary(original, 0, 1, 1, 1, &mut process)
+    })
+}
+
+fn with_tail_errors_badarg<T>(tail: T)
+where
+    T: FnOnce(&mut Process) -> Term,
+{
+    with(|_, head, mut process| {
+        let iolist = Term::cons(head, tail(&mut process), &mut process);
+
+        assert_badarg!(erlang::list_to_binary_1(iolist, &mut process));
+    });
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(u8, Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let head_byte: u8 = 0;
+        let head = head_byte.into_process(&mut process);
+
+        f(head_byte, head, &mut process);
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_heap_binary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_heap_binary.rs
@@ -1,0 +1,157 @@
+use super::*;
+
+#[test]
+fn with_atom_errors_badarg() {
+    with_tail_errors_badarg(|_| Term::str_to_atom("", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_errors_badarg() {
+    with_tail_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_returns_binary() {
+    with(|head, mut process| {
+        let tail = Term::EMPTY_LIST;
+        let iolist = Term::cons(head, tail, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[0, 1], &mut process))
+        );
+    })
+}
+
+#[test]
+fn with_list_with_byte_tail_errors_badarg() {
+    with_tail_errors_badarg(|mut process| {
+        let tail_head_byte = 3;
+        let tail_head = tail_head_byte.into_process(&mut process);
+
+        let tail_tail_byte = 4;
+        let tail_tail = tail_tail_byte.into_process(&mut process);
+
+        Term::cons(tail_head, tail_tail, &mut process)
+    })
+}
+
+#[test]
+fn with_list_without_byte_tail_returns_binary() {
+    with(|head, mut process| {
+        let tail_head_byte = 3;
+        let tail_head = tail_head_byte.into_process(&mut process);
+
+        let tail_tail = Term::EMPTY_LIST;
+
+        let tail = Term::cons(tail_head, tail_tail, &mut process);
+
+        let iolist = Term::cons(head, tail, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[0, 1, tail_head_byte], &mut process))
+        );
+    })
+}
+
+#[test]
+fn with_byte_errors_badarg() {
+    with_tail_errors_badarg(|mut process| 2.into_process(&mut process));
+}
+
+#[test]
+fn with_small_integer_with_byte_overflow_errors_badarg() {
+    with_tail_errors_badarg(|mut process| 256.into_process(&mut process));
+}
+
+#[test]
+fn with_big_integer_errors_badarg() {
+    with_tail_errors_badarg(|mut process| {
+        (crate::integer::small::MAX + 1).into_process(&mut process)
+    });
+}
+
+#[test]
+fn with_float_errors_badarg() {
+    with_tail_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_errors_badarg() {
+    with_tail_errors_badarg(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_errors_badarg() {
+    with_tail_errors_badarg(|mut process| Term::external_pid(1, 0, 0, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_errors_badarg() {
+    with_tail_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_errors_badarg() {
+    with_tail_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_returns_binary() {
+    with(|head, mut process| {
+        let tail = Term::slice_to_binary(&[2, 3], &mut process);
+
+        let iolist = Term::cons(head, tail, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[0, 1, 2, 3], &mut process))
+        );
+    })
+}
+
+#[test]
+fn with_subbinary_without_bitcount_returns_binary() {
+    with(|head, mut process| {
+        let original = Term::slice_to_binary(&[0b0111_1111, 0b1000_0000], &mut process);
+        let tail = Term::subbinary(original, 0, 1, 1, 0, &mut process);
+
+        let iolist = Term::cons(head, tail, &mut process);
+
+        assert_eq!(
+            erlang::list_to_binary_1(iolist, &mut process),
+            Ok(Term::slice_to_binary(&[0, 1, 255], &mut process))
+        );
+    })
+}
+
+#[test]
+fn with_subbinary_with_bitcount_errors_badarg() {
+    with_tail_errors_badarg(|mut process| {
+        let original = Term::slice_to_binary(&[0b0111_1111, 0b1100_0000], &mut process);
+        Term::subbinary(original, 0, 1, 1, 1, &mut process)
+    })
+}
+
+fn with_tail_errors_badarg<T>(tail: T)
+where
+    T: FnOnce(&mut Process) -> Term,
+{
+    with(|head, mut process| {
+        let iolist = Term::cons(head, tail(&mut process), &mut process);
+
+        assert_badarg!(erlang::list_to_binary_1(iolist, &mut process));
+    });
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let head = Term::slice_to_binary(&[0, 1], &mut process);
+
+        f(head, &mut process);
+    })
+}

--- a/lumen_runtime/src/term.rs
+++ b/lumen_runtime/src/term.rs
@@ -385,6 +385,16 @@ impl Term {
         process.slice_to_binary(slice).into()
     }
 
+    pub fn slice_to_list(slice: &[Term], mut process: &mut Process) -> Term {
+        Self::slice_to_improper_list(slice, Term::EMPTY_LIST, &mut process)
+    }
+
+    pub fn slice_to_improper_list(slice: &[Term], tail: Term, mut process: &mut Process) -> Term {
+        slice.iter().rfold(tail, |acc, element| {
+            Term::cons(element.clone(), acc, &mut process)
+        })
+    }
+
     pub fn slice_to_map(slice: &[(Term, Term)], process: &mut Process) -> Term {
         process.slice_to_map(slice).into()
     }


### PR DESCRIPTION
# Changelog
## Enhancements
* `:erlang.list_to_binary/1`.  Does not include the buffer-size precalculation or yielding of the BEAM version.