### PR TITLE
bitstring! macro

### DIFF
--- a/lumen_runtime/src/binary.rs
+++ b/lumen_runtime/src/binary.rs
@@ -10,8 +10,10 @@ use crate::list::{Cons, ToList};
 use crate::process::{IntoProcess, Process, TryIntoInProcess};
 use crate::term::{self, Tag::*, Term};
 
-pub mod heap;
+#[macro_use]
 pub mod sub;
+
+pub mod heap;
 
 pub enum Binary<'a> {
     Heap(&'a heap::Binary),

--- a/lumen_runtime/src/binary/sub.rs
+++ b/lumen_runtime/src/binary/sub.rs
@@ -15,6 +15,33 @@ use crate::integer::Integer;
 use crate::process::{IntoProcess, Process};
 use crate::term::{Tag::*, Term};
 
+#[cfg(test)]
+macro_rules! bitstring {
+    (@acc $bits:tt :: $bit_count:tt, $process:expr, $($byte:expr),*) => {{
+       use crate::term::Term;
+
+       let byte_count = <[()]>::len(&[$(replace_expr!($byte, ())),*]);
+       let original = Term::slice_to_binary(&[$( $byte, )* $bits << (8 - $bit_count)], $process);
+       Term::subbinary(original, 0, 0, byte_count, $bit_count, $process)
+    }};
+    (@acc $byte:expr, $($tail:tt)*) => {
+       bitstring!(@acc $($tail)*, $byte)
+    };
+    ($bits:tt :: $bit_count:tt, $process:expr) => {
+       bitstring!(@acc $bits :: $bit_count, $process,)
+    };
+    ($byte:expr, $($tail:tt)*) => {
+       bitstring!(@acc $($tail)*, $byte)
+    };
+}
+
+#[cfg(test)]
+macro_rules! replace_expr {
+    ($_t:expr, $sub:expr) => {
+        $sub
+    };
+}
+
 pub struct Binary {
     #[allow(dead_code)]
     header: Term,

--- a/lumen_runtime/src/lib.rs
+++ b/lumen_runtime/src/lib.rs
@@ -28,6 +28,8 @@ mod process;
 #[macro_use]
 mod exception;
 #[macro_use]
+mod binary;
+#[macro_use]
 mod integer;
 #[macro_use]
 mod number;
@@ -35,7 +37,6 @@ mod number;
 mod support;
 
 mod atom;
-mod binary;
 mod config;
 mod environment;
 mod float;

--- a/lumen_runtime/src/otp/erlang/tests/bit_size_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bit_size_1.rs
@@ -83,11 +83,10 @@ fn with_subbinary_is_eight_times_byte_count_plus_bit_count() {
     let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
     let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
     let mut process = process_rw_lock.write().unwrap();
-    let binary_term = Term::slice_to_binary(&[0, 1, 0b010], &mut process);
-    let subbinary_term = Term::subbinary(binary_term, 0, 0, 2, 3, &mut process);
+    let bitstring = bitstring!(0, 1, 0b010 :: 3, &mut process);
 
     assert_eq!(
-        erlang::bit_size_1(subbinary_term, &mut process),
+        erlang::bit_size_1(bitstring, &mut process),
         Ok(19.into_process(&mut process))
     );
 }

--- a/lumen_runtime/src/otp/erlang/tests/bitstring_to_list_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bitstring_to_list_1.rs
@@ -105,23 +105,15 @@ fn with_subbinary_with_bit_count_returns_list_of_integer_with_bitstring_for_bit_
     let environment_rw_lock: Arc<RwLock<Environment>> = Default::default();
     let process_rw_lock = environment::process(Arc::clone(&environment_rw_lock));
     let mut process = process_rw_lock.write().unwrap();
-    let original = Term::slice_to_binary(&[0, 1, 0b010], &mut process);
-    let bit_string = Term::subbinary(original, 0, 0, 2, 3, &mut process);
+    let bitstring = bitstring!(0, 1, 0b010 :: 3, &mut process);
 
     assert_eq!(
-        erlang::bitstring_to_list_1(bit_string, &mut process),
+        erlang::bitstring_to_list_1(bitstring, &mut process),
         Ok(Term::cons(
             0.into_process(&mut process),
             Term::cons(
                 1.into_process(&mut process),
-                Term::subbinary(
-                    Term::slice_to_binary(&[0, 1, 2], &mut process),
-                    2,
-                    0,
-                    0,
-                    3,
-                    &mut process
-                ),
+                bitstring!(0b010 :: 3, &mut process),
                 &mut process
             ),
             &mut process

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_0_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_0_bit_subbinary.rs
@@ -127,21 +127,12 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 #[test]
 fn with_subbinary_with_bit_count_1_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b1000_0000], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 1, &mut process);
-
+        let tail = bitstring!(2, 0b1 :: 1, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 0b0000_0010, 0b1000_0000], &mut process),
-                0,
-                0,
-                2,
-                1,
-                &mut process
-            ))
+            Ok(bitstring!(1, 2, 0b1 :: 1, &mut process))
         );
     });
 }
@@ -149,21 +140,12 @@ fn with_subbinary_with_bit_count_1_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_2_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b0100_0000], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 2, &mut process);
-
+        let tail = bitstring!(2, 0b01 :: 2, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 2, 0b0100_0000], &mut process),
-                0,
-                0,
-                2,
-                2,
-                &mut process
-            ))
+            Ok(bitstring!(1, 2, 0b01 :: 2, &mut process))
         );
     });
 }
@@ -171,21 +153,12 @@ fn with_subbinary_with_bit_count_2_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_3_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b1010_0000], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 3, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b101 :: 3, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 0b0000_0010, 0b1010_0000], &mut process),
-                0,
-                0,
-                2,
-                3,
-                &mut process
-            ))
+            Ok(bitstring!(1, 0b0000_0010, 0b101 :: 3, &mut process))
         );
     });
 }
@@ -193,21 +166,12 @@ fn with_subbinary_with_bit_count_3_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_4_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b0101_0000], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 4, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b0101 :: 4, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 0b0000_0010, 0b0101_0000], &mut process),
-                0,
-                0,
-                2,
-                4,
-                &mut process
-            ))
+            Ok(bitstring!(1, 0b0000_0010, 0b0101 :: 4, &mut process))
         );
     });
 }
@@ -215,21 +179,12 @@ fn with_subbinary_with_bit_count_4_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_5_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b1010_1000], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 5, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b1010_1 :: 5, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 0b0000_0010, 0b1010_1000], &mut process),
-                0,
-                0,
-                2,
-                5,
-                &mut process
-            ))
+            Ok(bitstring!(1, 0b0000_0010, 0b1010_1 :: 5, &mut process))
         );
     });
 }
@@ -237,21 +192,12 @@ fn with_subbinary_with_bit_count_5_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_6_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b0101_0100], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 6, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b0101_01 :: 6, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 0b0000_0010, 0b0101_0100], &mut process),
-                0,
-                0,
-                2,
-                6,
-                &mut process
-            ))
+            Ok(bitstring!(1, 0b0000_0010, 0b0101_01 :: 6, &mut process))
         );
     });
 }
@@ -259,21 +205,12 @@ fn with_subbinary_with_bit_count_6_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_7_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b1010_1010], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 7, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b1010_101 :: 7, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 0b0000_0010, 0b1010_1010], &mut process),
-                0,
-                0,
-                2,
-                7,
-                &mut process
-            ))
+            Ok(bitstring!(1, 0b0000_0010, 0b1010_101 :: 7, &mut process))
         );
     });
 }

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_1_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_1_bit_subbinary.rs
@@ -41,14 +41,7 @@ fn with_proper_list_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 255, 0], &mut process),
-                0,
-                0,
-                2,
-                1,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 255, 0 :: 1, &mut process))
         );
     })
 }
@@ -104,14 +97,7 @@ fn with_heap_binary_returns_bitstring() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 129, 130, 0 << (8 - 1)], &mut process),
-                0,
-                0,
-                1 + 2,
-                1,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 129, 130, 0 :: 1, &mut process))
         );
     })
 }
@@ -126,14 +112,7 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 0b1_0000000 | 0b0000000_1, 0b0_0000000], &mut process),
-                0,
-                0,
-                1 + 1,
-                1 + 0,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 0b1_0000000 | 0b0000000_1, 0b0 :: 1, &mut process))
         );
     });
 }
@@ -141,21 +120,12 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 #[test]
 fn with_subbinary_with_bit_count_1_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b1 << (8 - 1)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 1, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b1 :: 1, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 129, 1 << (8 - 2)], &mut process),
-                0,
-                0,
-                1 + 1,
-                1 + 1,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 129, 1 :: 2, &mut process))
         );
     });
 }
@@ -163,21 +133,12 @@ fn with_subbinary_with_bit_count_1_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_2_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b01 << (8 - 2)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 2, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b01 :: 2, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 129, 1 << (8 - 3)], &mut process),
-                0,
-                0,
-                1 + 1,
-                1 + 2,
-                &mut process
-            ))
+            Ok(bitstring!(1, 129, 1 :: 3, &mut process))
         );
     });
 }
@@ -185,21 +146,12 @@ fn with_subbinary_with_bit_count_2_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_3_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b101 << (8 - 3)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 3, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b101 :: 3, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 129, 5 << (8 - 4)], &mut process),
-                0,
-                0,
-                1 + 1,
-                1 + 3,
-                &mut process
-            ))
+            Ok(bitstring!(1, 129, 5 :: 4, &mut process))
         );
     });
 }
@@ -207,21 +159,12 @@ fn with_subbinary_with_bit_count_3_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_4_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b0101 << (8 - 4)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 4, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b0101 :: 4, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 129, 5 << (8 - 5)], &mut process),
-                0,
-                0,
-                1 + 1,
-                1 + 4,
-                &mut process
-            ))
+            Ok(bitstring!(1, 129, 5 :: 5, &mut process))
         );
     });
 }
@@ -229,21 +172,12 @@ fn with_subbinary_with_bit_count_4_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_5_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b10101 << (8 - 5)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 5, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b10101 :: 5, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 129, 21 << (8 - 6)], &mut process),
-                0,
-                0,
-                1 + 1,
-                1 + 5,
-                &mut process
-            ))
+            Ok(bitstring!(1, 129, 21 :: 6, &mut process))
         );
     });
 }
@@ -251,21 +185,12 @@ fn with_subbinary_with_bit_count_5_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_6_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b010101 << (8 - 6)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 6, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b010101 :: 6, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 129, 21 << (8 - 7)], &mut process),
-                0,
-                0,
-                1 + 1,
-                1 + 6,
-                &mut process
-            ))
+            Ok(bitstring!(1, 129, 21 :: 7, &mut process))
         );
     });
 }
@@ -273,9 +198,7 @@ fn with_subbinary_with_bit_count_6_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_7_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b1010101 << (8 - 7)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 7, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b1010101 :: 7, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
@@ -301,8 +224,7 @@ where
     F: FnOnce(Term, &mut Process) -> (),
 {
     with_process(|mut process| {
-        let original = Term::slice_to_binary(&[1, 0b1 << (8 - 1)], &mut process);
-        let head = Term::subbinary(original, 0, 0, 1, 1, &mut process);
+        let head = bitstring!(1, 0b1 :: 1, &mut process);
 
         f(head, &mut process);
     })

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_2_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_2_bit_subbinary.rs
@@ -41,14 +41,7 @@ fn with_proper_list_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 255, 2 << (8 - 2)], &mut process),
-                0,
-                0,
-                1 + 1,
-                2,
-                &mut process
-            ))
+            Ok(bitstring!(1, 255, 2 :: 2, &mut process))
         );
     })
 }
@@ -104,14 +97,7 @@ fn with_heap_binary_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 255, 191, 1 << (8 - 2)], &mut process),
-                0,
-                0,
-                3,
-                2,
-                &mut process
-            ))
+            Ok(bitstring!(1, 255, 191, 1 :: 2, &mut process))
         );
     })
 }
@@ -126,14 +112,7 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 192, 2 << (8 - 2)], &mut process),
-                0,
-                0,
-                1 + 1,
-                2 + 0,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 192, 2 :: 2, &mut process))
         );
     });
 }
@@ -141,21 +120,12 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 #[test]
 fn with_subbinary_with_bit_count_1_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[2, 0b1 << (8 - 1)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 1, &mut process);
-
+        let tail = bitstring!(2, 0b1 :: 1, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 192, 5 << (8 - 3)], &mut process),
-                0,
-                0,
-                1 + 1,
-                2 + 1,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 192, 5 :: 3, &mut process))
         );
     });
 }
@@ -163,21 +133,12 @@ fn with_subbinary_with_bit_count_1_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_2_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b11 << (8 - 2)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 2, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b11 :: 2, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 192, 11 << (8 - 4)], &mut process),
-                0,
-                0,
-                1 + 1,
-                2 + 2,
-                &mut process
-            ))
+            Ok(bitstring!(1, 192, 11 :: 4, &mut process))
         );
     });
 }
@@ -185,21 +146,12 @@ fn with_subbinary_with_bit_count_2_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_3_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b101 << (8 - 3)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 3, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b101 :: 3, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 192, 21 << (8 - 5)], &mut process),
-                0,
-                0,
-                1 + 1,
-                2 + 3,
-                &mut process
-            ))
+            Ok(bitstring!(1, 192, 21 :: 5, &mut process))
         );
     });
 }
@@ -207,21 +159,12 @@ fn with_subbinary_with_bit_count_3_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_4_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b0101 << (8 - 4)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 4, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b0101 :: 4, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 192, 37 << (8 - 6)], &mut process),
-                0,
-                0,
-                1 + 1,
-                2 + 4,
-                &mut process
-            ))
+            Ok(bitstring!(1, 192, 37 :: 6, &mut process))
         );
     });
 }
@@ -229,21 +172,12 @@ fn with_subbinary_with_bit_count_4_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_5_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b10101 << (8 - 5)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 5, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b10101 :: 5, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 192, 85 << (8 - 7)], &mut process),
-                0,
-                0,
-                1 + 1,
-                2 + 5,
-                &mut process
-            ))
+            Ok(bitstring!(1, 192, 85 :: 7, &mut process))
         );
     });
 }
@@ -251,9 +185,7 @@ fn with_subbinary_with_bit_count_5_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_6_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b010101 << (8 - 6)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 6, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b010101 :: 6, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
@@ -266,21 +198,12 @@ fn with_subbinary_with_bit_count_6_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_7_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b1010101 << (8 - 7)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 7, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b1010101 :: 7, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 192, 170, 1 << (8 - 1)], &mut process),
-                0,
-                0,
-                1 + 1 + (2 + 7) / 8,
-                (2 + 7) % 8,
-                &mut process
-            )),
+            Ok(bitstring!(1, 192, 170, 1 :: 1, &mut process)),
         )
     });
 }
@@ -301,8 +224,7 @@ where
     F: FnOnce(Term, &mut Process) -> (),
 {
     with_process(|mut process| {
-        let original = Term::slice_to_binary(&[1, 0b11 << (8 - 2)], &mut process);
-        let head = Term::subbinary(original, 0, 0, 1, 2, &mut process);
+        let head = bitstring!(1, 0b11 :: 2, &mut process);
 
         f(head, &mut process);
     })

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_3_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_3_bit_subbinary.rs
@@ -42,14 +42,7 @@ fn with_proper_list_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 191, 6 << (8 - 3)], &mut process),
-                0,
-                0,
-                1 + 1,
-                3,
-                &mut process
-            ))
+            Ok(bitstring!(1, 191, 6 :: 3, &mut process))
         );
     });
 }
@@ -105,14 +98,7 @@ fn with_heap_binary_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 191, 223, 5 << (8 - 3)], &mut process),
-                0,
-                0,
-                1 + 2,
-                3,
-                &mut process
-            ))
+            Ok(bitstring!(1, 191, 223, 5 :: 3, &mut process))
         );
     })
 }
@@ -127,14 +113,7 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 160, 2 << (8 - 3)], &mut process),
-                0,
-                0,
-                1 + 1,
-                3 + 0,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 160, 2 :: 3, &mut process))
         );
     });
 }
@@ -142,21 +121,12 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 #[test]
 fn with_subbinary_with_bit_count_1_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[2, 0b1 << (8 - 1)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 1, &mut process);
-
+        let tail = bitstring!(2, 0b1 :: 1, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 160, 5 << (8 - 4)], &mut process),
-                0,
-                0,
-                1 + 1,
-                3 + 1,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 160, 5 :: 4, &mut process))
         );
     });
 }
@@ -164,21 +134,12 @@ fn with_subbinary_with_bit_count_1_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_2_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b11 << (8 - 2)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 2, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b11 :: 2, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 160, 11 << (8 - 5)], &mut process),
-                0,
-                0,
-                1 + 1,
-                3 + 2,
-                &mut process
-            ))
+            Ok(bitstring!(1, 160, 11 :: 5, &mut process))
         );
     });
 }
@@ -186,21 +147,12 @@ fn with_subbinary_with_bit_count_2_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_3_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b101 << (8 - 3)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 3, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b101 :: 3, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 160, 21 << (8 - 6)], &mut process),
-                0,
-                0,
-                1 + 1,
-                3 + 3,
-                &mut process
-            ))
+            Ok(bitstring!(1, 160, 21 :: 6, &mut process))
         );
     });
 }
@@ -208,21 +160,12 @@ fn with_subbinary_with_bit_count_3_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_4_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b0101 << (8 - 4)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 4, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b0101 :: 4, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 160, 37 << (8 - 7)], &mut process),
-                0,
-                0,
-                1 + 1,
-                3 + 4,
-                &mut process
-            ))
+            Ok(bitstring!(1, 160, 37 :: 7, &mut process))
         );
     });
 }
@@ -230,9 +173,7 @@ fn with_subbinary_with_bit_count_4_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_5_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b10101 << (8 - 5)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 5, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b10101 :: 5, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
@@ -245,21 +186,12 @@ fn with_subbinary_with_bit_count_5_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_6_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b010101 << (8 - 6)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 6, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b010101 :: 6, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 160, 74, 1 << (8 - 1)], &mut process),
-                0,
-                0,
-                1 + 1 + (3 + 6) / 8,
-                (3 + 6) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 160, 74, 1 :: 1, &mut process))
         );
     });
 }
@@ -267,21 +199,12 @@ fn with_subbinary_with_bit_count_6_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_7_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b1010101 << (8 - 7)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 7, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b1010101 :: 7, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 160, 85, 1 << (8 - 2)], &mut process),
-                0,
-                0,
-                1 + 1 + (3 + 7) / 8,
-                (3 + 7) % 8,
-                &mut process
-            )),
+            Ok(bitstring!(1, 160, 85, 1 :: 2, &mut process)),
         )
     });
 }
@@ -302,8 +225,7 @@ where
     F: FnOnce(Term, &mut Process) -> (),
 {
     with_process(|mut process| {
-        let original = Term::slice_to_binary(&[1, 0b101 << (8 - 3)], &mut process);
-        let head = Term::subbinary(original, 0, 0, 1, 3, &mut process);
+        let head = bitstring!(1, 0b101 :: 3, &mut process);
 
         f(head, &mut process);
     })

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_4_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_4_bit_subbinary.rs
@@ -105,14 +105,7 @@ fn with_heap_binary_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 95, 239, 13 << (8 - 4)], &mut process),
-                0,
-                0,
-                1 + 2,
-                4,
-                &mut process
-            ))
+            Ok(bitstring!(1, 95, 239, 13 :: 4, &mut process))
         );
     })
 }
@@ -127,14 +120,7 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 80, 2 << (8 - 4)], &mut process),
-                0,
-                0,
-                1 + 1,
-                4 + 0,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 80, 2 :: 4, &mut process))
         );
     });
 }
@@ -142,21 +128,12 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 #[test]
 fn with_subbinary_with_bit_count_1_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[2, 0b1 << (8 - 1)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 1, &mut process);
-
+        let tail = bitstring!(2, 0b1 :: 1, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 80, 5 << (8 - 5)], &mut process),
-                0,
-                0,
-                1 + 1,
-                4 + 1,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 80, 5 :: 5, &mut process))
         );
     });
 }
@@ -164,21 +141,12 @@ fn with_subbinary_with_bit_count_1_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_2_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b11 << (8 - 2)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 2, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b11 :: 2, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 80, 11 << (8 - 6)], &mut process),
-                0,
-                0,
-                1 + 1,
-                4 + 2,
-                &mut process
-            ))
+            Ok(bitstring!(1, 80, 11 :: 6, &mut process))
         );
     });
 }
@@ -186,21 +154,12 @@ fn with_subbinary_with_bit_count_2_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_3_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b101 << (8 - 3)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 3, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b101 :: 3, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 80, 21 << (8 - 7)], &mut process),
-                0,
-                0,
-                1 + 1,
-                4 + 3,
-                &mut process
-            ))
+            Ok(bitstring!(1, 80, 21 :: 7, &mut process))
         );
     });
 }
@@ -208,9 +167,7 @@ fn with_subbinary_with_bit_count_3_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_4_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b0101 << (8 - 4)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 4, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b0101 :: 4, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
@@ -223,21 +180,12 @@ fn with_subbinary_with_bit_count_4_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_5_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b10101 << (8 - 5)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 5, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b10101 :: 5, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 80, 42, 1 << (8 - 1)], &mut process),
-                0,
-                0,
-                1 + 1 + (4 + 5) / 8,
-                (4 + 5) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 80, 42, 1 :: 1, &mut process))
         );
     });
 }
@@ -245,21 +193,12 @@ fn with_subbinary_with_bit_count_5_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_6_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b010101 << (8 - 6)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 6, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b010101 :: 6, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 80, 37, 1 << (8 - 2)], &mut process),
-                0,
-                0,
-                1 + 1 + (4 + 6) / 8,
-                (4 + 6) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 80, 37, 1 :: 2, &mut process))
         );
     });
 }
@@ -267,21 +206,12 @@ fn with_subbinary_with_bit_count_6_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_7_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b1010101 << (8 - 7)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 7, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b1010101 :: 7, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 80, 42, 5 << (8 - 3)], &mut process),
-                0,
-                0,
-                1 + 1 + (4 + 7) / 8,
-                (4 + 7) % 8,
-                &mut process
-            )),
+            Ok(bitstring!(1, 80, 42, 5 :: 3, &mut process)),
         )
     });
 }
@@ -302,8 +232,7 @@ where
     F: FnOnce(Term, &mut Process) -> (),
 {
     with_process(|mut process| {
-        let original = Term::slice_to_binary(&[1, 0b0101 << (8 - 4)], &mut process);
-        let head = Term::subbinary(original, 0, 0, 1, 4, &mut process);
+        let head = bitstring!(1, 0b0101 :: 4, &mut process);
 
         f(head, &mut process);
     })

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_5_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_5_bit_subbinary.rs
@@ -105,14 +105,7 @@ fn with_heap_binary_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 175, 247, 29 << (8 - 5)], &mut process),
-                0,
-                0,
-                1 + 2,
-                5,
-                &mut process
-            ))
+            Ok(bitstring!(1, 175, 247, 29 :: 5, &mut process))
         );
     })
 }
@@ -127,14 +120,7 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 168, 2 << (8 - 5)], &mut process),
-                0,
-                0,
-                1 + 1,
-                5 + 0,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 168, 2 :: 5, &mut process))
         );
     });
 }
@@ -142,21 +128,12 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 #[test]
 fn with_subbinary_with_bit_count_1_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[2, 0b1 << (8 - 1)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 1, &mut process);
-
+        let tail = bitstring!(2, 0b1 :: 1, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 168, 5 << (8 - 6)], &mut process),
-                0,
-                0,
-                1 + 1,
-                5 + 1,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 168, 5 :: 6, &mut process))
         );
     });
 }
@@ -164,21 +141,12 @@ fn with_subbinary_with_bit_count_1_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_2_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b11 << (8 - 2)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 2, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b11 :: 2, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 168, 11 << (8 - 7)], &mut process),
-                0,
-                0,
-                1 + 1,
-                5 + 2,
-                &mut process
-            ))
+            Ok(bitstring!(1, 168, 11 :: 7, &mut process))
         );
     });
 }
@@ -186,9 +154,7 @@ fn with_subbinary_with_bit_count_2_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_3_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b101 << (8 - 3)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 3, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b101 :: 3, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
@@ -201,21 +167,12 @@ fn with_subbinary_with_bit_count_3_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_4_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b0101 << (8 - 4)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 4, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b0101 :: 4, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 168, 18, 1 << (8 - 1)], &mut process),
-                0,
-                0,
-                1 + 1 + (5 + 4) / 8,
-                (5 + 4) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 168, 18, 1 :: 1, &mut process))
         );
     });
 }
@@ -223,21 +180,12 @@ fn with_subbinary_with_bit_count_4_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_5_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b10101 << (8 - 5)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 5, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b10101 :: 5, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 168, 21, 1 << (8 - 2)], &mut process),
-                0,
-                0,
-                1 + 1 + (5 + 5) / 8,
-                (5 + 5) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 168, 21, 1 :: 2, &mut process))
         );
     });
 }
@@ -245,21 +193,12 @@ fn with_subbinary_with_bit_count_5_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_6_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b010101 << (8 - 6)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 6, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b010101 :: 6, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 168, 18, 5 << (8 - 3)], &mut process),
-                0,
-                0,
-                1 + 1 + (5 + 6) / 8,
-                (5 + 6) % 8,
-                &mut process
-            ))
+            Ok(bitstring!( 1, 168, 18, 5 :: 3, &mut process))
         );
     });
 }
@@ -267,21 +206,12 @@ fn with_subbinary_with_bit_count_6_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_7_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b1010101 << (8 - 7)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 7, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b1010101 :: 7, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 168, 21, 5 << (8 - 4)], &mut process),
-                0,
-                0,
-                1 + 1 + (5 + 7) / 8,
-                (5 + 7) % 8,
-                &mut process
-            )),
+            Ok(bitstring!( 1, 168, 21, 5 :: 4, &mut process)),
         )
     });
 }
@@ -302,8 +232,7 @@ where
     F: FnOnce(Term, &mut Process) -> (),
 {
     with_process(|mut process| {
-        let original = Term::slice_to_binary(&[1, 0b10101 << (8 - 5)], &mut process);
-        let head = Term::subbinary(original, 0, 0, 1, 5, &mut process);
+        let head = bitstring!(1, 0b10101 :: 5, &mut process);
 
         f(head, &mut process);
     })

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_6_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_6_bit_subbinary.rs
@@ -42,14 +42,7 @@ fn with_proper_list_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 87, 62 << (8 - 6)], &mut process),
-                0,
-                0,
-                1 + 1,
-                6,
-                &mut process
-            ))
+            Ok(bitstring!(1, 87, 62 :: 6, &mut process))
         );
     });
 }
@@ -105,14 +98,7 @@ fn with_heap_binary_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 87, 251, 61 << (8 - 6)], &mut process),
-                0,
-                0,
-                1 + 2,
-                6,
-                &mut process
-            ))
+            Ok(bitstring!(1, 87, 251, 61 :: 6, &mut process))
         );
     })
 }
@@ -127,14 +113,7 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 84, 2 << (8 - 6)], &mut process),
-                0,
-                0,
-                1 + 1,
-                6 + 0,
-                &mut process,
-            ))
+            Ok(bitstring!( 1, 84, 2 :: 6, &mut process))
         );
     });
 }
@@ -142,21 +121,12 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 #[test]
 fn with_subbinary_with_bit_count_1_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[2, 0b1 << (8 - 1)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 1, &mut process);
-
+        let tail = bitstring!(2, 0b1 :: 1, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 84, 5 << (8 - 7)], &mut process),
-                0,
-                0,
-                1 + 1,
-                6 + 1,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 84, 5 :: 7, &mut process))
         );
     });
 }
@@ -164,9 +134,7 @@ fn with_subbinary_with_bit_count_1_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_2_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b11 << (8 - 2)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 2, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b11 :: 2, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
@@ -179,21 +147,12 @@ fn with_subbinary_with_bit_count_2_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_3_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b101 << (8 - 3)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 3, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b101 :: 3, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 84, 10, 1 << (8 - 1)], &mut process),
-                0,
-                0,
-                1 + 1 + (6 + 3) / 8,
-                (6 + 3) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 84, 10, 1 :: 1, &mut process))
         );
     });
 }
@@ -201,21 +160,12 @@ fn with_subbinary_with_bit_count_3_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_4_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b0101 << (8 - 4)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 4, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b0101 :: 4, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 84, 9, 1 << (8 - 2)], &mut process),
-                0,
-                0,
-                1 + 1 + (6 + 4) / 8,
-                (6 + 4) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 84, 9, 1 :: 2, &mut process))
         );
     });
 }
@@ -223,21 +173,13 @@ fn with_subbinary_with_bit_count_4_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_5_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b10101 << (8 - 5)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 5, &mut process);
+        let tail = bitstring!(0b0000_0010, 0b10101 :: 5, &mut process);
 
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 84, 10, 5 << (8 - 3)], &mut process),
-                0,
-                0,
-                1 + 1 + (6 + 5) / 8,
-                (6 + 5) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 84, 10, 5 :: 3, &mut process))
         );
     });
 }
@@ -245,21 +187,12 @@ fn with_subbinary_with_bit_count_5_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_6_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b010101 << (8 - 6)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 6, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b010101 :: 6, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 84, 9, 5 << (8 - 4)], &mut process),
-                0,
-                0,
-                1 + 1 + (6 + 6) / 8,
-                (6 + 6) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 84, 9, 5 :: 4, &mut process))
         );
     });
 }
@@ -267,21 +200,12 @@ fn with_subbinary_with_bit_count_6_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_7_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b1010101 << (8 - 7)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 7, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b1010101 :: 7, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 84, 10, 21 << (8 - 5)], &mut process),
-                0,
-                0,
-                1 + 1 + (6 + 7) / 8,
-                (6 + 7) % 8,
-                &mut process
-            )),
+            Ok(bitstring!(1, 84, 10, 21 :: 5, &mut process))
         )
     });
 }
@@ -302,8 +226,7 @@ where
     F: FnOnce(Term, &mut Process) -> (),
 {
     with_process(|mut process| {
-        let original = Term::slice_to_binary(&[1, 0b010101 << (8 - 6)], &mut process);
-        let head = Term::subbinary(original, 0, 0, 1, 6, &mut process);
+        let head = bitstring!(1, 0b010101 :: 6, &mut process);
 
         f(head, &mut process);
     })

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_7_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_7_bit_subbinary.rs
@@ -42,14 +42,7 @@ fn with_proper_list_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 171, 126 << (8 - 7)], &mut process),
-                0,
-                0,
-                1 + 1,
-                7,
-                &mut process
-            ))
+            Ok(bitstring!(1, 171, 126 :: 7, &mut process))
         );
     });
 }
@@ -105,14 +98,7 @@ fn with_heap_binary_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 171, 253, 125 << (8 - 7)], &mut process),
-                0,
-                0,
-                1 + 2,
-                7,
-                &mut process
-            ))
+            Ok(bitstring!(1, 171, 253, 125 :: 7, &mut process))
         );
     })
 }
@@ -127,14 +113,7 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 170, 2 << (8 - 7)], &mut process),
-                0,
-                0,
-                1 + 1,
-                7 + 0,
-                &mut process,
-            ))
+            Ok(bitstring!(1, 170, 2 :: 7, &mut process))
         );
     });
 }
@@ -142,9 +121,7 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 #[test]
 fn with_subbinary_with_bit_count_1_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[2, 0b1 << (8 - 1)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 1, &mut process);
-
+        let tail = bitstring!(2, 0b1 :: 1, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
@@ -157,21 +134,12 @@ fn with_subbinary_with_bit_count_1_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_2_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b11 << (8 - 2)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 2, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b11 :: 2, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 170, 5, 1 << (8 - 1)], &mut process),
-                0,
-                0,
-                1 + 1 + (7 + 2) / 8,
-                (7 + 2) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 170, 5, 1 :: 1, &mut process))
         );
     });
 }
@@ -179,21 +147,12 @@ fn with_subbinary_with_bit_count_2_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_3_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b101 << (8 - 3)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 3, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b101 :: 3, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 170, 5, 1 << (8 - 2)], &mut process),
-                0,
-                0,
-                1 + 1 + (7 + 3) / 8,
-                (7 + 3) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 170, 5, 1 :: 2, &mut process))
         );
     });
 }
@@ -201,21 +160,12 @@ fn with_subbinary_with_bit_count_3_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_4_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b0101 << (8 - 4)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 4, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b0101 :: 4, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 170, 4, 5 << (8 - 3)], &mut process),
-                0,
-                0,
-                1 + 1 + (7 + 4) / 8,
-                (7 + 4) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 170, 4, 5 :: 3, &mut process))
         );
     });
 }
@@ -223,21 +173,12 @@ fn with_subbinary_with_bit_count_4_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_5_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b10101 << (8 - 5)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 5, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b10101 :: 5, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 170, 5, 5 << (8 - 4)], &mut process),
-                0,
-                0,
-                1 + 1 + (7 + 5) / 8,
-                (7 + 5) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 170, 5, 5 :: 4, &mut process))
         );
     });
 }
@@ -245,21 +186,12 @@ fn with_subbinary_with_bit_count_5_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_6_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b010101 << (8 - 6)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 6, &mut process);
-
+        let tail = bitstring!(0b0000_0010, 0b010101 :: 6, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 170, 4, 21 << (8 - 5)], &mut process),
-                0,
-                0,
-                1 + 1 + (7 + 6) / 8,
-                (7 + 6) % 8,
-                &mut process
-            ))
+            Ok(bitstring!(1, 170, 4, 21 :: 5, &mut process))
         );
     });
 }
@@ -267,21 +199,12 @@ fn with_subbinary_with_bit_count_6_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_7_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0000_0010, 0b1010101 << (8 - 7)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 7, &mut process);
-
+        let tail = bitstring!(2, 0b1010101 :: 7, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[1, 170, 5, 21 << (8 - 6)], &mut process),
-                0,
-                0,
-                1 + 1 + (7 + 7) / 8,
-                (7 + 7) % 8,
-                &mut process
-            )),
+            Ok(bitstring!(1, 170, 5, 21 :: 6, &mut process))
         )
     });
 }
@@ -302,8 +225,7 @@ where
     F: FnOnce(Term, &mut Process) -> (),
 {
     with_process(|mut process| {
-        let original = Term::slice_to_binary(&[1, 0b1010101 << (8 - 7)], &mut process);
-        let head = Term::subbinary(original, 0, 0, 1, 7, &mut process);
+        let head = bitstring!(1, 0b1010101 :: 7, &mut process);
 
         f(head, &mut process);
     })

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_byte.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_byte.rs
@@ -124,21 +124,12 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 #[test]
 fn with_subbinary_with_bit_count_1_returns_subbinary() {
     with(|head_byte, head, mut process| {
-        let original = Term::slice_to_binary(&[2, 0b1 << (8 - 1)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 1, &mut process);
-
+        let tail = bitstring!(2, 0b1 :: 1, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[head_byte, 2, 128], &mut process),
-                0,
-                0,
-                2,
-                1,
-                &mut process
-            ))
+            Ok(bitstring!(head_byte, 2, 0b1 :: 1, &mut process))
         );
     });
 }
@@ -146,21 +137,12 @@ fn with_subbinary_with_bit_count_1_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_2_returns_subbinary() {
     with(|_head_byte, head, mut process| {
-        let original = Term::slice_to_binary(&[1, 0b11 << (8 - 2)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 2, &mut process);
-
+        let tail = bitstring!(1, 3 :: 2, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 3 << (8 - 2)], &mut process),
-                0,
-                0,
-                1 + 1,
-                2,
-                &mut process
-            ))
+            Ok(bitstring!(0, 1, 3 :: 2, &mut process))
         );
     });
 }
@@ -168,21 +150,13 @@ fn with_subbinary_with_bit_count_2_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_3_returns_subbinary() {
     with(|_head_byte, head, mut process| {
-        let original = Term::slice_to_binary(&[1, 0b101 << (8 - 3)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 3, &mut process);
+        let tail = bitstring!(1, 0b101 :: 3, &mut process);
 
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 0b101 << (8 - 3)], &mut process),
-                0,
-                0,
-                1 + 1,
-                3,
-                &mut process
-            ))
+            Ok(bitstring!(0, 1, 0b101 :: 3, &mut process))
         );
     });
 }
@@ -190,21 +164,12 @@ fn with_subbinary_with_bit_count_3_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_4_returns_subbinary() {
     with(|_head_byte, head, mut process| {
-        let original = Term::slice_to_binary(&[1, 0b0101 << (8 - 4)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 4, &mut process);
-
+        let tail = bitstring!(1, 0b0101 :: 4, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 0b0101 << (8 - 4)], &mut process),
-                0,
-                0,
-                1 + 1,
-                4,
-                &mut process
-            ))
+            Ok(bitstring!(0, 1, 0b0101 :: 4, &mut process))
         );
     });
 }
@@ -212,21 +177,12 @@ fn with_subbinary_with_bit_count_4_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_5_returns_subbinary() {
     with(|_head_byte, head, mut process| {
-        let original = Term::slice_to_binary(&[1, 0b10101 << (8 - 5)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 5, &mut process);
-
+        let tail = bitstring!(1, 0b10101 :: 5, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 0b10101 << (8 - 5)], &mut process),
-                0,
-                0,
-                1 + 1,
-                5,
-                &mut process
-            ))
+            Ok(bitstring!(0, 1, 0b10101 :: 5, &mut process))
         );
     });
 }
@@ -234,21 +190,12 @@ fn with_subbinary_with_bit_count_5_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_6_returns_subbinary() {
     with(|_head_byte, head, mut process| {
-        let original = Term::slice_to_binary(&[1, 0b010101 << (8 - 6)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 6, &mut process);
-
+        let tail = bitstring!(1, 0b010101 :: 6, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 0b010101 << (8 - 6)], &mut process),
-                0,
-                0,
-                1 + 1,
-                6,
-                &mut process
-            ))
+            Ok(bitstring!(0, 1, 0b010101 :: 6, &mut process))
         );
     });
 }
@@ -256,21 +203,12 @@ fn with_subbinary_with_bit_count_6_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_7_returns_subbinary() {
     with(|_head_byte, head, mut process| {
-        let original = Term::slice_to_binary(&[1, 0b1010101 << (8 - 7)], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 7, &mut process);
-
+        let tail = bitstring!(1, 0b1010101 :: 7, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 0b1010101 << (8 - 7)], &mut process),
-                0,
-                0,
-                1 + 1,
-                7,
-                &mut process
-            )),
+            Ok(bitstring!(0, 1, 0b1010101 :: 7, &mut process))
         )
     });
 }

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_heap_binary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_heap_binary.rs
@@ -124,21 +124,12 @@ fn with_subbinary_with_bit_count_0_returns_binary() {
 #[test]
 fn with_subbinary_with_bit_count_1_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b1010_1010, 0b1000_0000], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 1, &mut process);
-
+        let tail = bitstring!(0b1010_1010, 0b1 :: 1, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 0b1010_1010, 0b1000_0000], &mut process),
-                0,
-                0,
-                3,
-                1,
-                &mut process
-            ))
+            Ok(bitstring!(0, 1, 0b1010_1010, 0b1 :: 1, &mut process))
         );
     });
 }
@@ -146,21 +137,12 @@ fn with_subbinary_with_bit_count_1_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_2_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0101_0101, 0b0100_0000], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 2, &mut process);
-
+        let tail = bitstring!(0b0101_0101, 0b01 :: 2, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 0b0101_0101, 0b0100_0000], &mut process),
-                0,
-                0,
-                3,
-                2,
-                &mut process
-            ))
+            Ok(bitstring!(0, 1, 0b0101_0101, 0b01 :: 2, &mut process))
         );
     });
 }
@@ -168,21 +150,12 @@ fn with_subbinary_with_bit_count_2_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_3_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b1010_1010, 0b1010_0000], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 3, &mut process);
-
+        let tail = bitstring!(0b1010_1010, 0b101 :: 3, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 0b1010_1010, 0b1010_0000], &mut process),
-                0,
-                0,
-                3,
-                3,
-                &mut process
-            ))
+            Ok(bitstring!(0, 1, 0b1010_1010, 0b101 :: 3, &mut process))
         );
     });
 }
@@ -190,21 +163,12 @@ fn with_subbinary_with_bit_count_3_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_4_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0101_0101, 0b0101_0000], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 4, &mut process);
-
+        let tail = bitstring!(0b0101_0101, 0b0101 :: 4, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 0b0101_0101, 0b0101_0000], &mut process),
-                0,
-                0,
-                3,
-                4,
-                &mut process
-            ))
+            Ok(bitstring!(0, 1, 0b0101_0101, 0b0101 :: 4, &mut process))
         );
     });
 }
@@ -212,21 +176,12 @@ fn with_subbinary_with_bit_count_4_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_5_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b1010_1010, 0b1010_1000], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 5, &mut process);
-
+        let tail = bitstring!(0b1010_1010, 0b1010_1 :: 5, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 0b1010_1010, 0b1010_1000], &mut process),
-                0,
-                0,
-                3,
-                5,
-                &mut process
-            ))
+            Ok(bitstring!(0, 1, 0b1010_1010, 0b1010_1 :: 5, &mut process))
         );
     });
 }
@@ -234,21 +189,12 @@ fn with_subbinary_with_bit_count_5_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_6_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b0101_0101, 0b0101_0100], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 6, &mut process);
-
+        let tail = bitstring!(0b0101_0101, 0b0101_0100 :: 6, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 0b0101_0101, 0b0101_0100], &mut process),
-                0,
-                0,
-                3,
-                6,
-                &mut process
-            ))
+            Ok(bitstring!(0, 1, 0b0101_0101, 0b0101_0100 :: 6, &mut process))
         );
     });
 }
@@ -256,21 +202,12 @@ fn with_subbinary_with_bit_count_6_returns_subbinary() {
 #[test]
 fn with_subbinary_with_bit_count_7_returns_subbinary() {
     with(|head, mut process| {
-        let original = Term::slice_to_binary(&[0b1010_1010, 0b1010_1010], &mut process);
-        let tail = Term::subbinary(original, 0, 0, 1, 7, &mut process);
-
+        let tail = bitstring!(0b1010_1010, 0b1010_101 :: 7, &mut process);
         let iolist = Term::cons(head, tail, &mut process);
 
         assert_eq!(
             erlang::list_to_bitstring_1(iolist, &mut process),
-            Ok(Term::subbinary(
-                Term::slice_to_binary(&[0, 1, 0b1010_1010, 0b1010_1010], &mut process),
-                0,
-                0,
-                3,
-                7,
-                &mut process
-            ))
+            Ok(bitstring!(0, 1, 0b1010_1010, 0b1010_101 :: 7, &mut process))
         );
     });
 }


### PR DESCRIPTION
# Changelog
## Enhancements
* `bitstring!` macro supports a limited form of Elixir bitstring syntax:
  * `<<byte>>` as `bitstring!(byte, &mut process)`
  * `<<bits :: bit_count>>` as `bitstring!(bits :: bit_count, &mut process)`
  * `<<byte, bits :: bit_count>>` as `bitstring!(byte, bits :: bit_count, &mut process)`
  * `<<byte1, byte2, ..., byteN, bits :: bit_count>>` as `bitstring!(byte1, byte2, ..., byteN, bits :: bit_count, &mut process)`