### PR TITLE
band/2 infix operator

### DIFF
--- a/lumen_runtime/src/integer.rs
+++ b/lumen_runtime/src/integer.rs
@@ -10,6 +10,76 @@ use crate::exception::Exception;
 pub mod big;
 pub mod small;
 
+macro_rules! bitwise_infix_operator {
+    ($left:ident, $right:ident, $process:ident, $infix:tt) => {
+        match ($left.tag(), $right.tag()) {
+            (SmallInteger, SmallInteger) => {
+                let left_isize = unsafe { $left.small_integer_to_isize() };
+                let right_isize = unsafe { $right.small_integer_to_isize() };
+                let output = left_isize $infix right_isize;
+
+                Ok(output.into_process(&mut $process))
+            }
+            (SmallInteger, Boxed) => {
+                let unboxed_right: &Term = $right.unbox_reference();
+
+                match unboxed_right.tag() {
+                    BigInteger => {
+                        let left_isize = unsafe { $left.small_integer_to_isize() };
+                        let left_big_int: BigInt = left_isize.into();
+
+                        let right_big_integer: &big::Integer = $right.unbox_reference();
+                        let right_big_int = &right_big_integer.inner;
+
+                        let output_big_int = left_big_int $infix right_big_int;
+
+                        Ok(output_big_int.into_process(&mut $process))
+                    }
+                    _ => Err(badarith!()),
+                }
+            }
+            (Boxed, SmallInteger) => {
+                let unboxed_left: &Term = $left.unbox_reference();
+
+                match unboxed_left.tag() {
+                    BigInteger => {
+                        let left_big_integer: &big::Integer = $left.unbox_reference();
+                        let left_big_int = &left_big_integer.inner;
+
+                        let right_isize = unsafe { $right.small_integer_to_isize() };
+                        let right_big_int: BigInt = right_isize.into();
+
+                        let output_big_int = left_big_int $infix right_big_int;
+
+                        Ok(output_big_int.into_process(&mut $process))
+                    }
+                    _ => Err(badarith!()),
+                }
+            }
+            (Boxed, Boxed) => {
+                let unboxed_left: &Term = $left.unbox_reference();
+                let unboxed_right: &Term = $right.unbox_reference();
+
+                match (unboxed_left.tag(), unboxed_right.tag()) {
+                    (BigInteger, BigInteger) => {
+                        let left_big_integer: &big::Integer = $left.unbox_reference();
+                        let left_big_int = &left_big_integer.inner;
+
+                        let right_big_integer: &big::Integer = $right.unbox_reference();
+                        let right_big_int = &right_big_integer.inner;
+
+                        let output_big_int = left_big_int $infix right_big_int;
+
+                        Ok(output_big_int.into_process(&mut $process))
+                    }
+                    _ => Err(badarith!()),
+                }
+            }
+            _ => Err(badarith!()),
+        }
+    };
+}
+
 use crate::integer::big::big_int_to_usize;
 
 pub enum Integer {

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -112,6 +112,11 @@ pub fn atom_to_list_1(atom: Term, mut process: &mut Process) -> Result {
     }
 }
 
+// `band/2` infix operator.
+pub fn band_2(left_integer: Term, right_integer: Term, mut process: &mut Process) -> Result {
+    bitwise_infix_operator!(left_integer, right_integer, process, &)
+}
+
 pub fn binary_part_2(binary: Term, start_length: Term, mut process: &mut Process) -> Result {
     match start_length.tag() {
         Boxed => {

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -11,6 +11,7 @@ mod add_2;
 mod append_element_2;
 mod atom_to_binary_2;
 mod atom_to_list_1;
+mod band_2;
 mod binary_part_2;
 mod binary_part_3;
 mod binary_to_atom_2;

--- a/lumen_runtime/src/otp/erlang/tests/band_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/band_2.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+mod with_big_integer_left;
+mod with_small_integer_left;
+
+#[test]
+fn with_atom_left_errors_badarith() {
+    with_left_errors_badarith(|_| Term::str_to_atom("left", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_left_errors_badarith() {
+    with_left_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_float_errors_badarith() {
+    with_left_errors_badarith(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_left_errors_badarith() {
+    with_left_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| bitstring!(1 ::1, &mut process));
+}
+
+fn with_left_errors_badarith<L>(left: L)
+where
+    L: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let left = left(&mut process);
+        let right = 0.into_process(&mut process);
+
+        erlang::band_2(left, right, &mut process)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/band_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/band_2/with_big_integer_left.rs
@@ -1,0 +1,161 @@
+use super::*;
+
+use std::mem::size_of;
+
+use num_traits::Num;
+
+#[test]
+fn with_atom_right_errors_badarith() {
+    with_right_errors_badarith(|_| Term::str_to_atom("right", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_right_errors_badarith() {
+    with_right_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_right_returns_small_integer() {
+    with(|left, mut process| {
+        let right = 0b1010.into_process(&mut process);
+
+        assert_eq!(
+            erlang::band_2(left, right, &mut process),
+            Ok(0b1000.into_process(&mut process))
+        );
+    })
+}
+
+#[test]
+fn with_same_big_integer_right_returns_same_big_integer() {
+    with(|left, mut process| {
+        assert_eq!(erlang::band_2(left, left, &mut process), Ok(left));
+    })
+}
+
+#[test]
+fn with_big_integer_right_returns_big_integer() {
+    with(|left, mut process| {
+        let right = <BigInt as Num>::from_str_radix(
+            "1010".repeat(size_of::<usize>() * (8 / 4) * 2).as_ref(),
+            2,
+        )
+        .unwrap()
+        .into_process(&mut process);
+
+        assert_eq!(right.tag(), Boxed);
+
+        let unboxed_right: &Term = right.unbox_reference();
+
+        assert_eq!(unboxed_right.tag(), BigInteger);
+
+        let result = erlang::band_2(left, right, &mut process);
+
+        assert!(result.is_ok());
+
+        let output = result.unwrap();
+
+        println!("output = {:?}", output);
+
+        assert_eq!(output.tag(), Boxed);
+
+        let unboxed_output: &Term = output.unbox_reference();
+
+        assert_eq!(unboxed_output.tag(), BigInteger);
+        assert_eq!(
+            output,
+            <BigInt as Num>::from_str_radix(
+                "1000".repeat(size_of::<usize>() * (8 / 4) * 2).as_ref(),
+                2
+            )
+            .unwrap()
+            .into_process(&mut process)
+        );
+    })
+}
+
+#[test]
+fn with_float_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_right_errors_badarith() {
+    with_right_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| bitstring!(1 :: 1, &mut process));
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let left = <BigInt as Num>::from_str_radix(
+            "1100".repeat(size_of::<usize>() * (8 / 4) * 2).as_ref(),
+            2,
+        )
+        .unwrap()
+        .into_process(&mut process);
+
+        f(left, &mut process)
+    })
+}
+
+fn with_right_errors_badarith<M>(right: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let left = (crate::integer::small::MAX + 1).into_process(&mut process);
+
+        assert_eq!(left.tag(), Boxed);
+
+        let unboxed_left: &Term = left.unbox_reference();
+
+        assert_eq!(unboxed_left.tag(), BigInteger);
+
+        let right = right(&mut process);
+
+        erlang::band_2(left, right, &mut process)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/band_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/band_2/with_small_integer_left.rs
@@ -1,0 +1,147 @@
+use super::*;
+
+use std::mem::size_of;
+
+use num_traits::Num;
+
+#[test]
+fn with_atom_right_errors_badarith() {
+    with_right_errors_badarith(|_| Term::str_to_atom("right", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_right_errors_badarith() {
+    with_right_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_same_small_integer_right_returns_same_small_integer() {
+    with(|left, mut process| {
+        assert_eq!(erlang::band_2(left, left, &mut process), Ok(left));
+    })
+}
+
+#[test]
+fn with_small_integer_right_returns_small_integer() {
+    with_process(|mut process| {
+        // all combinations of `0` and `1` bit.
+        let left = 0b1100.into_process(&mut process);
+        let right = 0b1010.into_process(&mut process);
+
+        assert_eq!(
+            erlang::band_2(left, right, &mut process),
+            Ok(0b1000.into_process(&mut process))
+        );
+    })
+}
+
+#[test]
+fn with_big_integer_right_returns_small_integer() {
+    with_process(|mut process| {
+        let left: Term = 0b1100_1100_1100_1100_1100_1100_1100_isize.into_process(&mut process);
+
+        assert_eq!(left.tag(), SmallInteger);
+
+        let right = <BigInt as Num>::from_str_radix(
+            "1010".repeat(size_of::<usize>() * (8 / 4) * 2).as_ref(),
+            2,
+        )
+        .unwrap()
+        .into_process(&mut process);
+
+        assert_eq!(right.tag(), Boxed);
+
+        let unboxed_right: &Term = right.unbox_reference();
+
+        assert_eq!(unboxed_right.tag(), BigInteger);
+
+        let result = erlang::band_2(left, right, &mut process);
+
+        assert!(result.is_ok());
+
+        let output = result.unwrap();
+
+        assert_eq!(output.tag(), SmallInteger);
+        assert_eq!(
+            output,
+            0b1000_1000_1000_1000_1000_1000_1000_isize.into_process(&mut process)
+        );
+    })
+}
+
+#[test]
+fn with_float_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_right_errors_badarith() {
+    with_right_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| bitstring!(1 :: 1, &mut process));
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let left = 2.into_process(&mut process);
+
+        f(left, &mut process)
+    })
+}
+
+fn with_right_errors_badarith<M>(right: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let left: Term = 2.into_process(&mut process);
+
+        assert_eq!(left.tag(), SmallInteger);
+
+        let right = right(&mut process);
+
+        erlang::band_2(left, right, &mut process)
+    });
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `band/2` infix operator implemented as `erlang::band_2`.