### PR TITLE
bor/2 infix operator

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -364,6 +364,11 @@ pub fn bitstring_to_list_1(bit_string: Term, mut process: &mut Process) -> Resul
     }
 }
 
+// `bor/2` infix operator.
+pub fn bor_2(left_integer: Term, right_integer: Term, mut process: &mut Process) -> Result {
+    bitwise_infix_operator!(left_integer, right_integer, process, |)
+}
+
 pub fn byte_size_1(bit_string: Term, mut process: &mut Process) -> Result {
     match bit_string.tag() {
         Boxed => {

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -25,6 +25,7 @@ mod binary_to_term_1;
 mod binary_to_term_2;
 mod bit_size_1;
 mod bitstring_to_list_1;
+mod bor_2;
 mod byte_size_1;
 mod ceil_1;
 mod concatenate_2;

--- a/lumen_runtime/src/otp/erlang/tests/bor_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bor_2.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+mod with_big_integer_left;
+mod with_small_integer_left;
+
+#[test]
+fn with_atom_left_errors_badarith() {
+    with_left_errors_badarith(|_| Term::str_to_atom("left", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_left_errors_badarith() {
+    with_left_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_float_errors_badarith() {
+    with_left_errors_badarith(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_left_errors_badarith() {
+    with_left_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_left_errors_badarith() {
+    with_left_errors_badarith(|mut process| bitstring!(1 ::1, &mut process));
+}
+
+fn with_left_errors_badarith<L>(left: L)
+where
+    L: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let left = left(&mut process);
+        let right = 0.into_process(&mut process);
+
+        erlang::bor_2(left, right, &mut process)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/bor_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bor_2/with_big_integer_left.rs
@@ -1,0 +1,170 @@
+use super::*;
+
+use std::mem::size_of;
+
+use num_traits::Num;
+
+#[test]
+fn with_atom_right_errors_badarith() {
+    with_right_errors_badarith(|_| Term::str_to_atom("right", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_right_errors_badarith() {
+    with_right_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_right_returns_big_integer() {
+    with(|left, mut process| {
+        let right: Term = 0b1010_1010_1010_1010_1010_1010_1010.into_process(&mut process);
+
+        assert_eq!(right.tag(), SmallInteger);
+
+        let result = erlang::bor_2(left, right, &mut process);
+
+        assert!(result.is_ok());
+
+        let output = result.unwrap();
+
+        assert_eq!(output.tag(), Boxed);
+
+        let unboxed_output: &Term = output.unbox_reference();
+
+        assert_eq!(unboxed_output.tag(), BigInteger);
+    });
+}
+
+#[test]
+fn with_same_big_integer_right_returns_same_big_integer() {
+    with(|left, mut process| {
+        assert_eq!(erlang::bor_2(left, left, &mut process), Ok(left));
+    })
+}
+
+#[test]
+fn with_big_integer_right_returns_big_integer() {
+    with(|left, mut process| {
+        let right = <BigInt as Num>::from_str_radix(
+            "1010".repeat(size_of::<usize>() * (8 / 4) * 2).as_ref(),
+            2,
+        )
+        .unwrap()
+        .into_process(&mut process);
+
+        assert_eq!(right.tag(), Boxed);
+
+        let unboxed_right: &Term = right.unbox_reference();
+
+        assert_eq!(unboxed_right.tag(), BigInteger);
+
+        let result = erlang::bor_2(left, right, &mut process);
+
+        assert!(result.is_ok());
+
+        let output = result.unwrap();
+
+        println!("output = {:?}", output);
+
+        assert_eq!(output.tag(), Boxed);
+
+        let unboxed_output: &Term = output.unbox_reference();
+
+        assert_eq!(unboxed_output.tag(), BigInteger);
+        assert_eq!(
+            output,
+            <BigInt as Num>::from_str_radix(
+                "1110".repeat(size_of::<usize>() * (8 / 4) * 2).as_ref(),
+                2
+            )
+            .unwrap()
+            .into_process(&mut process)
+        );
+    })
+}
+
+#[test]
+fn with_float_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_right_errors_badarith() {
+    with_right_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| bitstring!(1 :: 1, &mut process));
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let left = <BigInt as Num>::from_str_radix(
+            "1100".repeat(size_of::<usize>() * (8 / 4) * 2).as_ref(),
+            2,
+        )
+        .unwrap()
+        .into_process(&mut process);
+
+        f(left, &mut process)
+    })
+}
+
+fn with_right_errors_badarith<M>(right: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let left = (crate::integer::small::MAX + 1).into_process(&mut process);
+
+        assert_eq!(left.tag(), Boxed);
+
+        let unboxed_left: &Term = left.unbox_reference();
+
+        assert_eq!(unboxed_left.tag(), BigInteger);
+
+        let right = right(&mut process);
+
+        erlang::bor_2(left, right, &mut process)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/bor_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bor_2/with_small_integer_left.rs
@@ -1,0 +1,147 @@
+use super::*;
+
+use std::mem::size_of;
+
+use num_traits::Num;
+
+#[test]
+fn with_atom_right_errors_badarith() {
+    with_right_errors_badarith(|_| Term::str_to_atom("right", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_right_errors_badarith() {
+    with_right_errors_badarith(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_same_small_integer_right_returns_same_small_integer() {
+    with(|left, mut process| {
+        assert_eq!(erlang::bor_2(left, left, &mut process), Ok(left));
+    })
+}
+
+#[test]
+fn with_small_integer_right_returns_small_integer() {
+    with_process(|mut process| {
+        // all combinations of `0` and `1` bit.
+        let left = 0b1100.into_process(&mut process);
+        let right = 0b1010.into_process(&mut process);
+
+        assert_eq!(
+            erlang::bor_2(left, right, &mut process),
+            Ok(0b1110.into_process(&mut process))
+        );
+    })
+}
+
+#[test]
+fn with_big_integer_right_returns_big_integer() {
+    with_process(|mut process| {
+        let left: Term = 0b1100_1100_1100_1100_1100_1100_1100_isize.into_process(&mut process);
+
+        assert_eq!(left.tag(), SmallInteger);
+
+        let right = <BigInt as Num>::from_str_radix(
+            "1010".repeat(size_of::<usize>() * (8 / 4) * 2).as_ref(),
+            2,
+        )
+        .unwrap()
+        .into_process(&mut process);
+
+        assert_eq!(right.tag(), Boxed);
+
+        let unboxed_right: &Term = right.unbox_reference();
+
+        assert_eq!(unboxed_right.tag(), BigInteger);
+
+        let result = erlang::bor_2(left, right, &mut process);
+
+        assert!(result.is_ok());
+
+        let output = result.unwrap();
+
+        assert_eq!(output.tag(), Boxed);
+
+        let unboxed_output: &Term = output.unbox_reference();
+
+        assert_eq!(unboxed_output.tag(), BigInteger);
+    })
+}
+
+#[test]
+fn with_float_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_right_errors_badarith() {
+    with_right_errors_badarith(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_right_errors_badarith() {
+    with_right_errors_badarith(|mut process| bitstring!(1 :: 1, &mut process));
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let left = 2.into_process(&mut process);
+
+        f(left, &mut process)
+    })
+}
+
+fn with_right_errors_badarith<M>(right: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarith(|mut process| {
+        let left: Term = 2.into_process(&mut process);
+
+        assert_eq!(left.tag(), SmallInteger);
+
+        let right = right(&mut process);
+
+        erlang::bor_2(left, right, &mut process)
+    });
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `bor/2` infix operator implemented as `erlang::bor_2`.