### PR TITLE
or/2 infix operator

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -1021,6 +1021,13 @@ pub fn number_or_badarith_1(term: Term) -> Result {
     }
 }
 
+/// `or/2` infix operator.
+///
+/// **NOTE: NOT SHORT-CIRCUITING!**
+pub fn or_2(left_boolean: Term, right_boolean: Term) -> Result {
+    boolean_infix_operator!(left_boolean, right_boolean, |)
+}
+
 pub fn raise_3(class: Term, reason: Term, stacktrace: Term) -> Result {
     let class_class: Class = class.try_into()?;
 

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -74,6 +74,7 @@ mod multiply_2;
 mod negate_1;
 mod node_0;
 mod number_or_badarith_1;
+mod or_2;
 mod raise_3;
 mod rem_2;
 mod self_0;

--- a/lumen_runtime/src/otp/erlang/tests/or_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/or_2.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+mod with_false_left;
+mod with_true_left;
+
+#[test]
+fn with_atom_left_errors_badarg() {
+    with_left_errors_badarg(|_| Term::str_to_atom("left", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_left_errors_badarg() {
+    with_left_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_float_errors_badarg() {
+    with_left_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_left_errors_badarg() {
+    with_left_errors_badarg(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| bitstring!(1 ::1, &mut process));
+}
+
+fn with_left_errors_badarg<L>(left: L)
+where
+    L: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarg(|mut process| {
+        let left = left(&mut process);
+        let right = 0.into_process(&mut process);
+
+        erlang::or_2(left, right)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/or_2/with_false_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/or_2/with_false_left.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+#[test]
+fn with_atom_right_errors_badarg() {
+    with_right_errors_badarg(|_| Term::str_to_atom("right", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_false_right_returns_false() {
+    with(|left, _| {
+        assert_eq!(erlang::or_2(left, false.into()), Ok(false.into()));
+    });
+}
+
+#[test]
+fn with_true_right_returns_true() {
+    with(|left, _| {
+        assert_eq!(erlang::or_2(left, true.into()), Ok(true.into()));
+    });
+}
+
+#[test]
+fn with_local_reference_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_right_errors_badarg() {
+    with_right_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| 1.into_process(&mut process))
+}
+
+#[test]
+fn with_big_integer_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| {
+        (crate::integer::small::MAX + 1).into_process(&mut process)
+    })
+}
+
+#[test]
+fn with_float_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_right_errors_badarg() {
+    with_right_errors_badarg(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| bitstring!(1 :: 1, &mut process));
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let left = false.into();
+
+        f(left, &mut process)
+    })
+}
+
+fn with_right_errors_badarg<M>(right: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarg(|mut process| {
+        let left = false.into();
+        let right = right(&mut process);
+
+        erlang::or_2(left, right)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/or_2/with_true_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/or_2/with_true_left.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+#[test]
+fn with_atom_right_errors_badarg() {
+    with_right_errors_badarg(|_| Term::str_to_atom("right", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_false_right_returns_true() {
+    with(|left, _| {
+        assert_eq!(erlang::or_2(left, false.into()), Ok(true.into()));
+    });
+}
+
+#[test]
+fn with_true_right_returns_true() {
+    with(|left, _| {
+        assert_eq!(erlang::or_2(left, true.into()), Ok(true.into()));
+    });
+}
+
+#[test]
+fn with_local_reference_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_right_errors_badarg() {
+    with_right_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| 1.into_process(&mut process))
+}
+
+#[test]
+fn with_big_integer_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| {
+        (crate::integer::small::MAX + 1).into_process(&mut process)
+    })
+}
+
+#[test]
+fn with_float_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_right_errors_badarg() {
+    with_right_errors_badarg(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| bitstring!(1 :: 1, &mut process));
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let left = true.into();
+
+        f(left, &mut process)
+    })
+}
+
+fn with_right_errors_badarg<M>(right: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarg(|mut process| {
+        let left = true.into();
+        let right = right(&mut process);
+
+        erlang::or_2(left, right)
+    });
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `or/2` infix operator. `or/2` is not short-circuiting in Erlang.