### PR TITLE
xor/2 infix operator

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -1268,6 +1268,13 @@ pub fn tuple_to_list_1(tuple: Term, mut process: &mut Process) -> Result {
     }
 }
 
+/// `xor/2` infix operator.
+///
+/// **NOTE: NOT SHORT-CIRCUITING!**
+pub fn xor_2(left_boolean: Term, right_boolean: Term) -> Result {
+    boolean_infix_operator!(left_boolean, right_boolean, ^)
+}
+
 // Private Functions
 
 fn binary_existence_to_atom(binary: Term, encoding: Term, existence: Existence) -> Result {

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -87,6 +87,7 @@ mod throw_1;
 mod tl_1;
 mod tuple_size_1;
 mod tuple_to_list_1;
+mod xor_2;
 
 fn errors_badarg<F>(actual: F)
 where

--- a/lumen_runtime/src/otp/erlang/tests/xor_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/xor_2.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+mod with_false_left;
+mod with_true_left;
+
+#[test]
+fn with_atom_left_errors_badarg() {
+    with_left_errors_badarg(|_| Term::str_to_atom("left", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_left_errors_badarg() {
+    with_left_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_float_errors_badarg() {
+    with_left_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_left_errors_badarg() {
+    with_left_errors_badarg(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| bitstring!(1 ::1, &mut process));
+}
+
+fn with_left_errors_badarg<L>(left: L)
+where
+    L: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarg(|mut process| {
+        let left = left(&mut process);
+        let right = 0.into_process(&mut process);
+
+        erlang::xor_2(left, right)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/xor_2/with_false_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/xor_2/with_false_left.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+#[test]
+fn with_atom_right_errors_badarg() {
+    with_right_errors_badarg(|_| Term::str_to_atom("right", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_false_right_returns_false() {
+    with(|left, _| {
+        assert_eq!(erlang::xor_2(left, false.into()), Ok(false.into()));
+    });
+}
+
+#[test]
+fn with_true_right_returns_true() {
+    with(|left, _| {
+        assert_eq!(erlang::xor_2(left, true.into()), Ok(true.into()));
+    });
+}
+
+#[test]
+fn with_local_reference_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_right_errors_badarg() {
+    with_right_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| 1.into_process(&mut process))
+}
+
+#[test]
+fn with_big_integer_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| {
+        (crate::integer::small::MAX + 1).into_process(&mut process)
+    })
+}
+
+#[test]
+fn with_float_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_right_errors_badarg() {
+    with_right_errors_badarg(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| bitstring!(1 :: 1, &mut process));
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let left = false.into();
+
+        f(left, &mut process)
+    })
+}
+
+fn with_right_errors_badarg<M>(right: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarg(|mut process| {
+        let left = false.into();
+        let right = right(&mut process);
+
+        erlang::xor_2(left, right)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/xor_2/with_true_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/xor_2/with_true_left.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+#[test]
+fn with_atom_right_errors_badarg() {
+    with_right_errors_badarg(|_| Term::str_to_atom("right", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_false_right_returns_true() {
+    with(|left, _| {
+        assert_eq!(erlang::xor_2(left, false.into()), Ok(true.into()));
+    });
+}
+
+#[test]
+fn with_true_right_returns_false() {
+    with(|left, _| {
+        assert_eq!(erlang::xor_2(left, true.into()), Ok(false.into()));
+    });
+}
+
+#[test]
+fn with_local_reference_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_right_errors_badarg() {
+    with_right_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| 1.into_process(&mut process))
+}
+
+#[test]
+fn with_big_integer_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| {
+        (crate::integer::small::MAX + 1).into_process(&mut process)
+    })
+}
+
+#[test]
+fn with_float_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_right_errors_badarg() {
+    with_right_errors_badarg(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_right_errors_badarg() {
+    with_right_errors_badarg(|mut process| bitstring!(1 :: 1, &mut process));
+}
+
+fn with<F>(f: F)
+where
+    F: FnOnce(Term, &mut Process) -> (),
+{
+    with_process(|mut process| {
+        let left = true.into();
+
+        f(left, &mut process)
+    })
+}
+
+fn with_right_errors_badarg<M>(right: M)
+where
+    M: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarg(|mut process| {
+        let left = true.into();
+        let right = right(&mut process);
+
+        erlang::xor_2(left, right)
+    });
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `xor/2` infix operator.  `xor/2` in Erlang is not short-circuiting.