### PR TITLE
andalso/2 infix operator

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -88,9 +88,25 @@ pub fn add_2(augend: Term, addend: Term, mut process: &mut Process) -> Result {
 
 /// `and/2` infix operator.
 ///
-/// **NOTE: NOT SHORT-CIRCUITING!**
+/// **NOTE: NOT SHORT-CIRCUITING!**  Use `andalso/2` for short-circuiting, but it doesn't enforce
+/// that `right` is boolean.
 pub fn and_2(left_boolean: Term, right_boolean: Term) -> Result {
     boolean_infix_operator!(left_boolean, right_boolean, &)
+}
+
+/// `andalso/2` infix operator.
+///
+/// Short-circuiting, but doesn't enforce `right` is boolean.  If you need to enforce `boolean` for
+/// both operands, use `and_2`.
+pub fn andalso_2(boolean: Term, term: Term) -> Result {
+    let boolean_bool: bool = boolean.try_into()?;
+
+    if boolean_bool {
+        Ok(term)
+    } else {
+        // always `false.into()`, but this is faster
+        Ok(boolean)
+    }
 }
 
 pub fn append_element_2(tuple: Term, element: Term, mut process: &mut Process) -> Result {

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -9,6 +9,7 @@ use crate::otp::erlang;
 mod abs_1;
 mod add_2;
 mod and_2;
+mod andalso_2;
 mod append_element_2;
 mod atom_to_binary_2;
 mod atom_to_list_1;

--- a/lumen_runtime/src/otp/erlang/tests/andalso_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/andalso_2.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+mod with_false_left;
+mod with_true_left;
+
+#[test]
+fn with_atom_left_errors_badarg() {
+    with_left_errors_badarg(|_| Term::str_to_atom("left", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_left_errors_badarg() {
+    with_left_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_float_errors_badarg() {
+    with_left_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_left_errors_badarg() {
+    with_left_errors_badarg(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| bitstring!(1 ::1, &mut process));
+}
+
+fn with_left_errors_badarg<L>(left: L)
+where
+    L: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarg(|mut process| {
+        let left = left(&mut process);
+        let right = 0.into_process(&mut process);
+
+        erlang::andalso_2(left, right)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/andalso_2/with_false_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/andalso_2/with_false_left.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_false() {
+    with_right_returns_false(|mut _process| Term::str_to_atom("right", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_false_right_returns_false() {
+    with_right_returns_false(|_| false.into());
+}
+
+#[test]
+fn with_true_right_returns_false() {
+    with_right_returns_false(|_| true.into());
+}
+
+#[test]
+fn with_local_reference_right_returns_false() {
+    with_right_returns_false(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_right_returns_false() {
+    with_right_returns_false(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_right_returns_false() {
+    with_right_returns_false(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_right_returns_false() {
+    with_right_returns_false(|mut process| 1.into_process(&mut process))
+}
+
+#[test]
+fn with_big_integer_right_returns_false() {
+    with_right_returns_false(|mut process| {
+        (crate::integer::small::MAX + 1).into_process(&mut process)
+    })
+}
+
+#[test]
+fn with_float_right_returns_false() {
+    with_right_returns_false(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_right_returns_false() {
+    with_right_returns_false(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_right_returns_false() {
+    with_right_returns_false(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_right_returns_false() {
+    with_right_returns_false(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_right_returns_false() {
+    with_right_returns_false(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_right_returns_false() {
+    with_right_returns_false(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_right_returns_false() {
+    with_right_returns_false(|mut process| bitstring!(1 :: 1, &mut process));
+}
+
+fn with_right_returns_false<R>(right: R)
+where
+    R: FnOnce(&mut Process) -> Term,
+{
+    with_process(|mut process| {
+        let left = false.into();
+        let right = right(&mut process);
+
+        assert_eq!(erlang::andalso_2(left, right), Ok(left));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/andalso_2/with_true_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/andalso_2/with_true_left.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_right() {
+    with_right_returns_right(|mut _process| Term::str_to_atom("right", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_false_right_returns_right() {
+    with_right_returns_right(|_| false.into());
+}
+
+#[test]
+fn with_true_right_returns_right() {
+    with_right_returns_right(|_| true.into());
+}
+
+#[test]
+fn with_local_reference_right_returns_right() {
+    with_right_returns_right(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_right_returns_right() {
+    with_right_returns_right(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_right_returns_right() {
+    with_right_returns_right(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_right_returns_right() {
+    with_right_returns_right(|mut process| 1.into_process(&mut process))
+}
+
+#[test]
+fn with_big_integer_right_returns_right() {
+    with_right_returns_right(|mut process| {
+        (crate::integer::small::MAX + 1).into_process(&mut process)
+    })
+}
+
+#[test]
+fn with_float_right_returns_right() {
+    with_right_returns_right(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_right_returns_right() {
+    with_right_returns_right(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_right_returns_right() {
+    with_right_returns_right(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_right_returns_right() {
+    with_right_returns_right(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_right_returns_right() {
+    with_right_returns_right(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_right_returns_right() {
+    with_right_returns_right(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_right_returns_right() {
+    with_right_returns_right(|mut process| bitstring!(1 :: 1, &mut process));
+}
+
+fn with_right_returns_right<R>(right: R)
+where
+    R: FnOnce(&mut Process) -> Term,
+{
+    with_process(|mut process| {
+        let left = true.into();
+        let right = right(&mut process);
+
+        assert_eq!(erlang::andalso_2(left, right), Ok(right));
+    });
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `andalso/2` infix operator.  `andalso/2` is the short-circuiting "and" operator of Erlang, but it
doesn't enforce that the right operand is boolean.