### PR TITLE
orelse/2 infix operator

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -558,6 +558,21 @@ pub fn element_2(tuple: Term, index: Term, mut process: &mut Process) -> Result 
     inner_tuple.element(index_zero_based)
 }
 
+/// `orelse/2` infix operator.
+///
+/// Short-circuiting, but doesn't enforce `right` is boolean.  If you need to enforce `boolean` for
+/// both operands, use `or_2`.
+pub fn orelse_2(boolean: Term, term: Term) -> Result {
+    let boolean_bool: bool = boolean.try_into()?;
+
+    if boolean_bool {
+        // always `true.into()`, but this is faster
+        Ok(boolean)
+    } else {
+        Ok(term)
+    }
+}
+
 pub fn error_1(reason: Term) -> Result {
     Err(error!(reason))
 }

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -77,6 +77,7 @@ mod node_0;
 mod not_1;
 mod number_or_badarith_1;
 mod or_2;
+mod orelse_2;
 mod raise_3;
 mod rem_2;
 mod self_0;

--- a/lumen_runtime/src/otp/erlang/tests/orelse_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/orelse_2.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+mod with_false_left;
+mod with_true_left;
+
+#[test]
+fn with_atom_left_errors_badarg() {
+    with_left_errors_badarg(|_| Term::str_to_atom("left", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_left_errors_badarg() {
+    with_left_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_float_errors_badarg() {
+    with_left_errors_badarg(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_left_errors_badarg() {
+    with_left_errors_badarg(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_left_errors_badarg() {
+    with_left_errors_badarg(|mut process| bitstring!(1 ::1, &mut process));
+}
+
+fn with_left_errors_badarg<L>(left: L)
+where
+    L: FnOnce(&mut Process) -> Term,
+{
+    super::errors_badarg(|mut process| {
+        let left = left(&mut process);
+        let right = 0.into_process(&mut process);
+
+        erlang::orelse_2(left, right)
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/orelse_2/with_false_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/orelse_2/with_false_left.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_true() {
+    with_right_returns_right(|mut _process| Term::str_to_atom("right", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_false_right_returns_true() {
+    with_right_returns_right(|_| false.into());
+}
+
+#[test]
+fn with_true_right_returns_true() {
+    with_right_returns_right(|_| true.into());
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    with_right_returns_right(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    with_right_returns_right(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    with_right_returns_right(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_right_returns_true() {
+    with_right_returns_right(|mut process| 1.into_process(&mut process))
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    with_right_returns_right(|mut process| {
+        (crate::integer::small::MAX + 1).into_process(&mut process)
+    })
+}
+
+#[test]
+fn with_float_right_returns_true() {
+    with_right_returns_right(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    with_right_returns_right(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    with_right_returns_right(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    with_right_returns_right(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_right_returns_true() {
+    with_right_returns_right(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    with_right_returns_right(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    with_right_returns_right(|mut process| bitstring!(1 :: 1, &mut process));
+}
+
+fn with_right_returns_right<R>(right: R)
+where
+    R: FnOnce(&mut Process) -> Term,
+{
+    with_process(|mut process| {
+        let left = false.into();
+        let right = right(&mut process);
+
+        assert_eq!(erlang::orelse_2(left, right), Ok(right));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/orelse_2/with_true_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/orelse_2/with_true_left.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_true() {
+    with_right_returns_true(|mut _process| Term::str_to_atom("right", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_false_right_returns_true() {
+    with_right_returns_true(|_| false.into());
+}
+
+#[test]
+fn with_true_right_returns_true() {
+    with_right_returns_true(|_| true.into());
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    with_right_returns_true(|mut process| Term::local_reference(&mut process));
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    with_right_returns_true(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    with_right_returns_true(|mut process| {
+        Term::cons(
+            0.into_process(&mut process),
+            1.into_process(&mut process),
+            &mut process,
+        )
+    });
+}
+
+#[test]
+fn with_small_integer_right_returns_true() {
+    with_right_returns_true(|mut process| 1.into_process(&mut process))
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    with_right_returns_true(|mut process| {
+        (crate::integer::small::MAX + 1).into_process(&mut process)
+    })
+}
+
+#[test]
+fn with_float_right_returns_true() {
+    with_right_returns_true(|mut process| 1.0.into_process(&mut process));
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    with_right_returns_true(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    with_right_returns_true(|mut process| Term::external_pid(1, 2, 3, &mut process).unwrap());
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    with_right_returns_true(|mut process| Term::slice_to_tuple(&[], &mut process));
+}
+
+#[test]
+fn with_map_is_right_returns_true() {
+    with_right_returns_true(|mut process| Term::slice_to_map(&[], &mut process));
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    with_right_returns_true(|mut process| Term::slice_to_binary(&[], &mut process));
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    with_right_returns_true(|mut process| bitstring!(1 :: 1, &mut process));
+}
+
+fn with_right_returns_true<R>(right: R)
+where
+    R: FnOnce(&mut Process) -> Term,
+{
+    with_process(|mut process| {
+        let left = true.into();
+        let right = right(&mut process);
+
+        assert_eq!(erlang::orelse_2(left, right), Ok(left));
+    });
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `orelse/2` infix operator.  `orelse/2` is the short-circuiting "or" operator of Erlang, but it
doesn't enforce that the right operand is boolean.