### PR TITLE
=/=/2

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -121,6 +121,11 @@ pub fn are_exactly_equal_2(left: Term, right: Term) -> Term {
     left.eq(&right).into()
 }
 
+/// `=/=/2` infix operator.  Unlike `!=`, does not convert between floats and integers.
+pub fn are_exactly_not_equal_2(left: Term, right: Term) -> Term {
+    left.ne(&right).into()
+}
+
 pub fn atom_to_binary_2(atom: Term, encoding: Term, mut process: &mut Process) -> Result {
     if atom.tag() == Atom {
         encoding.atom_to_encoding()?;

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -12,6 +12,7 @@ mod and_2;
 mod andalso_2;
 mod append_element_2;
 mod are_exactly_equal_2;
+mod are_exactly_not_equal_2;
 mod atom_to_binary_2;
 mod atom_to_list_1;
 mod band_2;

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+mod with_atom_left;
+mod with_big_integer_left;
+mod with_empty_list_left;
+mod with_external_pid_left;
+mod with_float_left;
+mod with_heap_binary_left;
+mod with_list_left;
+mod with_local_pid_left;
+mod with_local_reference_left;
+mod with_map_left;
+mod with_small_integer_left;
+mod with_subbinary_left;
+mod with_tuple_left;
+
+fn are_exactly_not_equal<L, R>(left: L, right: R, expected: bool)
+where
+    L: FnOnce(&mut Process) -> Term,
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    with_process(|mut process| {
+        let left = left(&mut process);
+        let right = right(left, &mut process);
+
+        assert_eq!(
+            erlang::are_exactly_not_equal_2(left, right),
+            expected.into()
+        );
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_atom_left.rs
@@ -1,0 +1,108 @@
+use super::*;
+
+#[test]
+fn with_same_atom_returns_false() {
+    are_exactly_not_equal(|left, _| left, false);
+}
+
+#[test]
+fn with_same_atom_value_returns_false() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("left", DoNotCare).unwrap(), false);
+}
+
+#[test]
+fn with_different_atom_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true);
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, true);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_small_integer_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(0, 1).unwrap(), true);
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_map_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::slice_to_map(&[], &mut process), true);
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(
+        |_| Term::str_to_atom("left", DoNotCare).unwrap(),
+        right,
+        expected,
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_big_integer_left.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+#[test]
+fn with_atom_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true);
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, true);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_small_integer_right_returns_false() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), false)
+}
+
+#[test]
+fn with_same_big_integer_right_returns_false() {
+    are_exactly_not_equal(|left, _| left, false)
+}
+
+#[test]
+fn with_same_value_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_different_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MIN - 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_same_value_float_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| ((crate::integer::small::MAX + 1) as f64).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_different_value_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 1.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(0, 1).unwrap(), true);
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_map_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::slice_to_map(&[], &mut process), true);
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(|mut process| 0.into_process(&mut process), right, expected);
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_empty_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_empty_list_left.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true)
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_false() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, false);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_small_integer_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(0, 1).unwrap(), true);
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_map_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::slice_to_map(&[], &mut process), true);
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(|_| Term::EMPTY_LIST, right, expected);
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_external_pid_left.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true)
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, true);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_small_integer_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(2, 3).unwrap(), true);
+}
+
+#[test]
+fn with_same_external_pid_right_returns_false() {
+    are_exactly_not_equal(|left, _| left, false);
+}
+
+#[test]
+fn with_same_value_external_pid_right_returns_false() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        false,
+    );
+}
+
+#[test]
+fn with_different_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(4, 5, 6, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_map_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::slice_to_map(&[], &mut process), true);
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(
+        |mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        right,
+        expected,
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_float_left.rs
@@ -1,0 +1,118 @@
+use super::*;
+
+#[test]
+fn with_atom_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true);
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, true);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_same_small_integer_right_returns_false() {
+    are_exactly_not_equal(|left, _| left, false)
+}
+
+#[test]
+fn with_same_value_small_integer_right_returns_false() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), false)
+}
+
+#[test]
+fn with_different_small_integer_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 1.into_process(&mut process), true)
+}
+
+#[test]
+fn with_same_value_big_integer_right_returns_true() {
+    super::are_exactly_not_equal(
+        |mut process| ((crate::integer::small::MAX + 1) as f64).into_process(&mut process),
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_different_value_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_same_value_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_different_value_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 1.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(0, 1).unwrap(), true);
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_map_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::slice_to_map(&[], &mut process), true);
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(|mut process| 0.into_process(&mut process), right, expected);
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_heap_binary_left.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true)
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, true);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_small_integer_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(2, 3).unwrap(), true);
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_map_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::slice_to_map(&[], &mut process), true);
+}
+
+#[test]
+fn with_same_heap_binary_right_returns_false() {
+    are_exactly_not_equal(|left, _| left, false);
+}
+
+#[test]
+fn with_same_value_heap_binary_right_returns_false() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        false,
+    );
+}
+
+#[test]
+fn with_different_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[1], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(
+        |mut process| Term::slice_to_binary(&[], &mut process),
+        right,
+        expected,
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_list_left.rs
@@ -1,0 +1,123 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true)
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, true);
+}
+
+#[test]
+fn with_same_list_right_returns_false() {
+    are_exactly_not_equal(|left, _| left, false);
+}
+
+#[test]
+fn with_same_value_list_right_returns_false() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        false,
+    );
+}
+
+#[test]
+fn with_different_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                2.into_process(&mut process),
+                3.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_small_integer_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(0, 1).unwrap(), true);
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_map_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::slice_to_map(&[], &mut process), true);
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(
+        |mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        right,
+        expected,
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_local_pid_left.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true)
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, true);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_small_integer_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_same_local_pid_returns_false() {
+    are_exactly_not_equal(|left, _| left, false);
+}
+
+#[test]
+fn with_same_value_local_pid_right_returns_false() {
+    are_exactly_not_equal(|_, _| Term::local_pid(0, 1).unwrap(), false);
+}
+
+#[test]
+fn with_different_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(2, 3).unwrap(), true);
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_map_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::slice_to_map(&[], &mut process), true);
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(|_| Term::local_pid(0, 1).unwrap(), right, expected);
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_local_reference_left.rs
@@ -1,0 +1,103 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true)
+}
+
+#[test]
+fn with_same_local_reference_right_returns_false() {
+    are_exactly_not_equal(|left, _| left, false);
+}
+
+#[test]
+fn with_different_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, true);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_small_integer_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(0, 1).unwrap(), true);
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_map_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::slice_to_map(&[], &mut process), true);
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(
+        |mut process| Term::local_reference(&mut process),
+        right,
+        expected,
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_map_left.rs
@@ -1,0 +1,122 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true)
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, true);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_small_integer_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(2, 3).unwrap(), true);
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_same_map_right_returns_false() {
+    are_exactly_not_equal(|left, _| left, false);
+}
+
+#[test]
+fn with_same_value_map_right_returns_false() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_map(&[], &mut process),
+        false,
+    );
+}
+
+#[test]
+fn with_different_map_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::slice_to_map(
+                &[(
+                    Term::str_to_atom("a", DoNotCare).unwrap(),
+                    1.into_process(&mut process),
+                )],
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(
+        |mut process| Term::slice_to_map(&[], &mut process),
+        right,
+        expected,
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_small_integer_left.rs
@@ -1,0 +1,109 @@
+use super::*;
+
+#[test]
+fn with_atom_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true);
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, true);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_same_small_integer_right_returns_false() {
+    are_exactly_not_equal(|left, _| left, false)
+}
+
+#[test]
+fn with_same_value_small_integer_right_returns_false() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), false)
+}
+
+#[test]
+fn with_different_small_integer_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 1.into_process(&mut process), true)
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_same_value_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_different_value_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 1.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(0, 1).unwrap(), true);
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_map_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::slice_to_map(&[], &mut process), true);
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(|mut process| 0.into_process(&mut process), right, expected);
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_subbinary_left.rs
@@ -1,0 +1,108 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true)
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, true);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_small_integer_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(2, 3).unwrap(), true);
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_map_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::slice_to_map(&[], &mut process), true);
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_same_subbinary_right_returns_false() {
+    are_exactly_not_equal(|left, _| left, false);
+}
+
+#[test]
+fn with_same_value_subbinary_right_returns_false() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), false);
+}
+
+#[test]
+fn with_different_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(2 :: 2, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(
+        |mut process| bitstring!(1 :: 1, &mut process),
+        right,
+        expected,
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_tuple_left.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+#[test]
+fn with_atom_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::str_to_atom("right", DoNotCare).unwrap(), true)
+}
+
+#[test]
+fn with_local_reference_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::local_reference(&mut process), true);
+}
+
+#[test]
+fn with_empty_list_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::EMPTY_LIST, true);
+}
+
+#[test]
+fn with_list_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| {
+            Term::cons(
+                0.into_process(&mut process),
+                1.into_process(&mut process),
+                &mut process,
+            )
+        },
+        true,
+    );
+}
+
+#[test]
+fn with_small_integer_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_big_integer_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| (crate::integer::small::MAX + 1).into_process(&mut process),
+        true,
+    )
+}
+
+#[test]
+fn with_float_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| 0.0.into_process(&mut process), true)
+}
+
+#[test]
+fn with_local_pid_right_returns_true() {
+    are_exactly_not_equal(|_, _| Term::local_pid(2, 3).unwrap(), true);
+}
+
+#[test]
+fn with_external_pid_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::external_pid(1, 2, 3, &mut process).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn with_same_tuple_right_returns_false() {
+    are_exactly_not_equal(|left, _| left, false);
+}
+
+#[test]
+fn with_same_value_tuple_right_returns_false() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[], &mut process),
+        false,
+    );
+}
+
+#[test]
+fn with_different_tuple_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_tuple(&[1.into_process(&mut process)], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_map_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| Term::slice_to_map(&[], &mut process), true);
+}
+
+#[test]
+fn with_heap_binary_right_returns_true() {
+    are_exactly_not_equal(
+        |_, mut process| Term::slice_to_binary(&[], &mut process),
+        true,
+    );
+}
+
+#[test]
+fn with_subbinary_right_returns_true() {
+    are_exactly_not_equal(|_, mut process| bitstring!(1 :: 1, &mut process), true);
+}
+
+fn are_exactly_not_equal<R>(right: R, expected: bool)
+where
+    R: FnOnce(Term, &mut Process) -> Term,
+{
+    super::are_exactly_not_equal(
+        |mut process| Term::slice_to_tuple(&[], &mut process),
+        right,
+        expected,
+    );
+}


### PR DESCRIPTION
# Changelog
## Enhancements
*  Map Erlang's "exactly not equal" to "erlang::are_exactly_not_equal_2", which then calls Rust's `ne`.