### PR TITLE
:erlang.send/2 and !/2 infix operator

### DIFF
--- a/lumen_runtime/src/binary/heap.rs
+++ b/lumen_runtime/src/binary/heap.rs
@@ -10,6 +10,7 @@ use crate::binary::{
     PartToList, ToTerm, ToTermOptions,
 };
 use crate::exception::Exception;
+use crate::heap::{CloneIntoHeap, Heap};
 use crate::integer::Integer;
 use crate::process::{IntoProcess, Process};
 use crate::term::Term;
@@ -106,6 +107,12 @@ pub struct BitCountIter {
     byte: u8,
     current_bit_offset: u8,
     max_bit_offset: u8,
+}
+
+impl CloneIntoHeap for &'static Binary {
+    fn clone_into_heap(&self, heap: &Heap) -> &'static Binary {
+        heap.slice_to_heap_binary(self.as_slice())
+    }
 }
 
 #[cfg(test)]

--- a/lumen_runtime/src/binary/sub.rs
+++ b/lumen_runtime/src/binary/sub.rs
@@ -11,6 +11,7 @@ use crate::binary::{
     PartToList, ToTerm, ToTermOptions,
 };
 use crate::exception::{self, Exception};
+use crate::heap::{CloneIntoHeap, Heap};
 use crate::integer::Integer;
 use crate::process::{IntoProcess, Process};
 use crate::term::{Tag::*, Term};
@@ -190,6 +191,20 @@ impl Binary {
             0,
             self.bit_count,
             &process,
+        )
+    }
+}
+
+impl CloneIntoHeap for &'static Binary {
+    fn clone_into_heap(&self, heap: &Heap) -> &'static Binary {
+        let heap_original = self.original.clone_into_heap(heap);
+
+        heap.subbinary(
+            heap_original,
+            self.byte_count,
+            self.bit_offset,
+            self.byte_count,
+            self.bit_count,
         )
     }
 }

--- a/lumen_runtime/src/float.rs
+++ b/lumen_runtime/src/float.rs
@@ -1,5 +1,6 @@
 use std::hash::{Hash, Hasher};
 
+use crate::heap::{CloneIntoHeap, Heap};
 use crate::term::{Tag, Term};
 
 pub const INTEGRAL_MIN: f64 = -9007199254740992.0;
@@ -29,6 +30,12 @@ impl Float {
         } else {
             overflowing
         }
+    }
+}
+
+impl CloneIntoHeap for &'static Float {
+    fn clone_into_heap(&self, heap: &Heap) -> &'static Float {
+        heap.f64_to_float(self.inner)
     }
 }
 

--- a/lumen_runtime/src/heap.rs
+++ b/lumen_runtime/src/heap.rs
@@ -1,0 +1,178 @@
+use im::hashmap::HashMap;
+use num_bigint::BigInt;
+
+use liblumen_arena::TypedArena;
+
+use crate::binary;
+use crate::float::Float;
+use crate::integer::big;
+use crate::list::Cons;
+use crate::map::Map;
+use crate::process::identifier;
+use crate::reference;
+use crate::term::Term;
+use crate::tuple::Tuple;
+
+pub struct Heap {
+    big_integer_arena: TypedArena<big::Integer>,
+    byte_arena: TypedArena<u8>,
+    cons_arena: TypedArena<Cons>,
+    external_pid_arena: TypedArena<identifier::External>,
+    float_arena: TypedArena<Float>,
+    heap_binary_arena: TypedArena<binary::heap::Binary>,
+    map_arena: TypedArena<Map>,
+    local_reference_arena: TypedArena<reference::local::Reference>,
+    subbinary_arena: TypedArena<binary::sub::Binary>,
+    term_arena: TypedArena<Term>,
+}
+
+impl Heap {
+    pub fn alloc_term_slice(&self, slice: &[Term]) -> *const Term {
+        self.term_arena.alloc_slice(slice).as_ptr()
+    }
+
+    /// Combines the two `Term`s into a list `Term`.  The list is only a proper list if the `tail`
+    /// is a list `Term` (`Term.tag` is `List`) or empty list (`Term.tag` is `EmptyList`).
+    pub fn cons(&self, head: Term, tail: Term) -> &'static Cons {
+        let pointer = self.cons_arena.alloc(Cons::new(head, tail)) as *const Cons;
+
+        unsafe { &*pointer }
+    }
+
+    pub fn external_pid(
+        &self,
+        node: usize,
+        number: usize,
+        serial: usize,
+    ) -> &'static identifier::External {
+        let pointer = self
+            .external_pid_arena
+            .alloc(identifier::External::new(node, number, serial))
+            as *const identifier::External;
+
+        unsafe { &*pointer }
+    }
+
+    pub fn f64_to_float(&self, f: f64) -> &'static Float {
+        let pointer = self.float_arena.alloc(Float::new(f)) as *const Float;
+
+        unsafe { &*pointer }
+    }
+
+    pub fn im_hash_map_to_map(&self, hash_map: HashMap<Term, Term>) -> &'static Map {
+        let pointer = self.map_arena.alloc(Map::new(hash_map)) as *const Map;
+
+        unsafe { &*pointer }
+    }
+
+    pub fn local_reference(&self) -> &'static reference::local::Reference {
+        let pointer = self
+            .local_reference_arena
+            .alloc(reference::local::Reference::next())
+            as *const reference::local::Reference;
+
+        unsafe { &*pointer }
+    }
+
+    #[cfg(test)]
+    pub fn number_to_local_reference(&self, number: u64) -> &'static reference::local::Reference {
+        let pointer = self
+            .local_reference_arena
+            .alloc(reference::local::Reference::new(number))
+            as *const reference::local::Reference;
+
+        unsafe { &*pointer }
+    }
+
+    pub fn num_bigint_big_to_big_integer(&self, big_int: BigInt) -> &'static big::Integer {
+        let pointer =
+            self.big_integer_arena.alloc(big::Integer::new(big_int)) as *const big::Integer;
+
+        unsafe { &*pointer }
+    }
+
+    pub fn subbinary(
+        &self,
+        original: Term,
+        byte_offset: usize,
+        bit_offset: u8,
+        byte_count: usize,
+        bit_count: u8,
+    ) -> &'static binary::sub::Binary {
+        let pointer = self.subbinary_arena.alloc(binary::sub::Binary::new(
+            original,
+            byte_offset,
+            bit_offset,
+            byte_count,
+            bit_count,
+        )) as *const binary::sub::Binary;
+
+        unsafe { &*pointer }
+    }
+
+    pub fn slice_to_binary(&self, slice: &[u8]) -> binary::Binary<'static> {
+        // TODO use reference counted binaries for bytes.len() > 64
+        let heap_binary = self.slice_to_heap_binary(slice);
+
+        binary::Binary::Heap(heap_binary)
+    }
+
+    pub fn slice_to_heap_binary(&self, bytes: &[u8]) -> &'static binary::heap::Binary {
+        let arena_bytes: &[u8] = if bytes.len() != 0 {
+            self.byte_arena.alloc_slice(bytes)
+        } else {
+            &[]
+        };
+
+        let pointer = self
+            .heap_binary_arena
+            .alloc(binary::heap::Binary::new(arena_bytes))
+            as *const binary::heap::Binary;
+
+        unsafe { &*pointer }
+    }
+
+    pub fn slice_to_map(&self, slice: &[(Term, Term)]) -> &'static Map {
+        let mut inner: HashMap<Term, Term> = HashMap::new();
+
+        for (key, value) in slice {
+            inner.insert(key.clone(), value.clone());
+        }
+
+        self.im_hash_map_to_map(inner)
+    }
+
+    pub fn slice_to_tuple(&self, slice: &[Term]) -> &'static Tuple {
+        Tuple::from_slice(slice, &self)
+    }
+
+    pub fn u64_to_local_reference(&self, number: u64) -> &'static reference::local::Reference {
+        let pointer = self
+            .local_reference_arena
+            .alloc(reference::local::Reference::new(number))
+            as *const reference::local::Reference;
+
+        unsafe { &*pointer }
+    }
+}
+
+pub trait CloneIntoHeap {
+    fn clone_into_heap(&self, heap: &Heap) -> Self;
+}
+
+impl Default for Heap {
+    fn default() -> Heap {
+        Heap {
+            big_integer_arena: Default::default(),
+            byte_arena: Default::default(),
+            cons_arena: Default::default(),
+            external_pid_arena: Default::default(),
+            float_arena: Default::default(),
+            heap_binary_arena: Default::default(),
+            map_arena: Default::default(),
+            local_reference_arena: Default::default(),
+            subbinary_arena: Default::default(),
+            term_arena: Default::default(),
+        }
+    }
+}

--- a/lumen_runtime/src/integer/big.rs
+++ b/lumen_runtime/src/integer/big.rs
@@ -5,6 +5,7 @@ use num_bigint::{BigInt, Sign::*};
 use num_traits::Float;
 
 use crate::exception::Exception;
+use crate::heap::{CloneIntoHeap, Heap};
 use crate::term::{Tag::BigInteger, Term};
 
 pub struct Integer {
@@ -21,6 +22,12 @@ impl Integer {
             },
             inner,
         }
+    }
+}
+
+impl CloneIntoHeap for &'static Integer {
+    fn clone_into_heap(&self, heap: &Heap) -> &'static Integer {
+        heap.num_bigint_big_to_big_integer(self.inner.clone())
     }
 }
 

--- a/lumen_runtime/src/lib.rs
+++ b/lumen_runtime/src/lib.rs
@@ -38,9 +38,12 @@ mod support;
 
 mod config;
 mod float;
+mod heap;
 mod list;
 mod logging;
+mod mailbox;
 mod map;
+mod message;
 pub mod otp;
 mod reference;
 mod registry;

--- a/lumen_runtime/src/mailbox.rs
+++ b/lumen_runtime/src/mailbox.rs
@@ -1,0 +1,27 @@
+#[cfg(test)]
+use std::slice::Iter;
+
+use crate::message::Message;
+
+pub struct Mailbox {
+    messages: Vec<Message>,
+}
+
+impl Mailbox {
+    pub fn push(&mut self, message: Message) {
+        self.messages.push(message)
+    }
+
+    #[cfg(test)]
+    pub fn iter(&self) -> Iter<Message> {
+        self.messages.iter()
+    }
+}
+
+impl Default for Mailbox {
+    fn default() -> Mailbox {
+        Mailbox {
+            messages: Default::default(),
+        }
+    }
+}

--- a/lumen_runtime/src/map.rs
+++ b/lumen_runtime/src/map.rs
@@ -4,6 +4,7 @@ use im::hashmap::HashMap;
 
 use crate::atom::Existence::DoNotCare;
 use crate::exception::Result;
+use crate::heap::{CloneIntoHeap, Heap};
 use crate::integer::Integer;
 use crate::process::Process;
 use crate::term::{Tag, Term};
@@ -56,6 +57,18 @@ impl Map {
         key_vec.sort_unstable_by(|key1, key2| key1.cmp(&key2));
 
         key_vec
+    }
+}
+
+impl CloneIntoHeap for &'static Map {
+    fn clone_into_heap(&self, heap: &Heap) -> &'static Map {
+        let mut heap_inner: HashMap<Term, Term> = HashMap::new();
+
+        for (key, value) in &self.inner {
+            heap_inner.insert(key.clone_into_heap(heap), value.clone_into_heap(heap));
+        }
+
+        heap.im_hash_map_to_map(heap_inner)
     }
 }
 

--- a/lumen_runtime/src/message.rs
+++ b/lumen_runtime/src/message.rs
@@ -1,0 +1,10 @@
+use crate::heap;
+use crate::term::Term;
+
+pub enum Message {
+    /// A message whose `Term` is allocated inside the receiving `Process`'s `Heap`.
+    Process(Term),
+    /// A message whose `message` `Term` had to be allocated in `heap` outside of the receiving
+    /// `Process` because the `Process`'s `Heap` was locked.
+    Heap { heap: heap::Heap, message: Term },
+}

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -94,6 +94,7 @@ mod register_2;
 mod registered_0;
 mod rem_2;
 mod self_0;
+mod send_2;
 mod setelement_3;
 mod size_1;
 mod split_binary_2;

--- a/lumen_runtime/src/otp/erlang/tests/register_2/with_atom_name/without_registered_name/with_local_pid.rs
+++ b/lumen_runtime/src/otp/erlang/tests/register_2/with_atom_name/without_registered_name/with_local_pid.rs
@@ -25,7 +25,7 @@ fn with_same_process() {
             erlang::register_2(name, pid_or_port, process_arc.clone()),
             Ok(true.into())
         );
-        assert_eq!(*process_arc.registered_name.lock().unwrap(), Some(name));
+        assert_eq!(*process_arc.registered_name.read().unwrap(), Some(name));
         assert_eq!(
             registry::RW_LOCK_REGISTERED_BY_NAME
                 .read()
@@ -49,7 +49,7 @@ fn with_different_process() {
             Ok(true.into())
         );
         assert_eq!(
-            *another_process_arc.registered_name.lock().unwrap(),
+            *another_process_arc.registered_name.read().unwrap(),
             Some(name)
         );
         assert_eq!(

--- a/lumen_runtime/src/otp/erlang/tests/send_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+use crate::message::Message;
+
+mod with_atom_destination;
+mod with_local_pid_destination;
+mod with_tuple_destination;
+
+#[test]
+fn with_local_reference_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_empty_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| {
+        (crate::integer::small::MAX + 1).into_process(&process)
+    });
+}
+
+#[test]
+fn with_float_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 0.0.into_process(&process));
+}
+
+#[test]
+fn with_external_pid_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::external_pid(1, 2, 3, &process).unwrap());
+}
+
+#[test]
+fn with_map_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_heap_binary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_binary(&[], &process));
+}
+
+#[test]
+fn with_subbinary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| bitstring!(1 :: 1, &process));
+}
+
+fn with_destination_errors_badarg<D>(destination: D)
+where
+    D: FnOnce(&Process) -> Term,
+{
+    with_process(|process| {
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::send_2(destination(process), message, process));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod registered;
+mod unregistered;

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_different_process.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_locked;
+mod without_locked;

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_different_process/with_locked.rs
@@ -1,0 +1,128 @@
+use super::*;
+
+#[test]
+fn with_atom_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_big_integer_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        (crate::integer::small::MAX + 1).into_process(&process)
+    });
+}
+
+#[test]
+fn with_float_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        0.0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_local_pid_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|_| {
+        Term::local_pid(0, 1).unwrap()
+    });
+}
+
+#[test]
+fn with_external_pid_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::external_pid(1, 2, 3, &process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_tuple(&[], &process)
+    });
+}
+
+#[test]
+fn with_map_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_map(&[], &process)
+    });
+}
+
+#[test]
+fn with_heap_binary_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_binary(&[], &process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(
+        |process| bitstring!(1 :: 1, &process),
+    );
+}
+
+fn with_message_adds_heap_message_to_mailbox_and_returns_message<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let different_process = process::local::new();
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, different_process.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let _different_process_heap_lock = different_process.heap.lock().unwrap();
+
+        let destination = different_process.pid;
+        let message = message(&process_arc);
+
+        assert_eq!(
+            erlang::send_2(destination, message, &process_arc),
+            Ok(message)
+        );
+
+        assert!(different_process
+            .mailbox
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|mailbox_message| match mailbox_message {
+                Message::Heap {
+                    message: heap_message,
+                    ..
+                } => heap_message == &message,
+                _ => false,
+            }))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_different_process/without_locked.rs
@@ -1,0 +1,116 @@
+use super::*;
+
+#[test]
+fn with_atom_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_local_reference_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_empty_list_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(|process| {
+        (crate::integer::small::MAX + 1).into_process(&process)
+    });
+}
+
+#[test]
+fn with_float_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(|process| 0.0.into_process(&process));
+}
+
+#[test]
+fn with_local_pid_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::external_pid(1, 2, 3, &process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_tuple(&[], &process)
+    });
+}
+
+#[test]
+fn with_map_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_map(&[], &process)
+    });
+}
+
+#[test]
+fn with_heap_binary_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_binary(&[], &process)
+    });
+}
+
+#[test]
+fn with_subbinary_adds_process_message_to_mailbox_and_returns_message() {
+    with_adds_process_message_to_mailbox_and_returns_message(
+        |process| bitstring!(1 :: 1, &process),
+    );
+}
+
+fn with_adds_process_message_to_mailbox_and_returns_message<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let different_process = process::local::new();
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, different_process.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let message = message(&process_arc);
+
+        assert_eq!(
+            erlang::send_2(destination, message, &process_arc),
+            Ok(message)
+        );
+
+        assert!(different_process
+            .mailbox
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|mailbox_message| match mailbox_message {
+                Message::Process(process_message) => process_message == &message,
+                _ => false,
+            }))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_same_process.rs
@@ -1,0 +1,121 @@
+use super::*;
+
+#[test]
+fn with_atom_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_big_integer_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        (crate::integer::small::MAX + 1).into_process(&process)
+    });
+}
+
+#[test]
+fn with_float_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        0.0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_local_pid_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|_| {
+        Term::local_pid(0, 1).unwrap()
+    });
+}
+
+#[test]
+fn with_external_pid_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::external_pid(1, 2, 3, &process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_tuple(&[], &process)
+    });
+}
+
+#[test]
+fn with_map_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_map(&[], &process)
+    });
+}
+
+#[test]
+fn with_heap_binary_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_binary(&[], &process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(
+        |process| bitstring!(1 :: 1, &process),
+    );
+}
+
+fn with_message_adds_process_message_to_mailbox_and_returns_message<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let message = message(&process_arc);
+
+        assert_eq!(
+            erlang::send_2(destination, message, &process_arc),
+            Ok(message)
+        );
+
+        assert!(process_arc
+            .mailbox
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|mailbox_message| match mailbox_message {
+                Message::Process(process_message) => process_message == &message,
+                _ => false,
+            }))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/unregistered.rs
@@ -1,0 +1,80 @@
+use super::*;
+
+#[test]
+fn with_atom_message_errors_badarg() {
+    with_message_errors_badarg(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_local_reference_message_errors_badarg() {
+    with_message_errors_badarg(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_empty_list_message_errors_badarg() {
+    with_message_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_errors_badarg() {
+    with_message_errors_badarg(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_message_errors_badarg() {
+    with_message_errors_badarg(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_message_errors_badarg() {
+    with_message_errors_badarg(|process| (crate::integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_float_message_errors_badarg() {
+    with_message_errors_badarg(|process| 0.0.into_process(&process));
+}
+
+#[test]
+fn with_local_pid_message_errors_badarg() {
+    with_message_errors_badarg(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_message_errors_badarg() {
+    with_message_errors_badarg(|process| Term::external_pid(1, 2, 3, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_message_errors_badarg() {
+    with_message_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_message_errors_badarg() {
+    with_message_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_heap_binary_message_errors_badarg() {
+    with_message_errors_badarg(|process| Term::slice_to_binary(&[], &process));
+}
+
+#[test]
+fn with_subbinary_message_errors_badarg() {
+    with_message_errors_badarg(|process| bitstring!(1 :: 1, &process));
+}
+
+fn with_message_errors_badarg<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process(|process| {
+        let destination = registered_name();
+        let message = message(process);
+
+        assert_badarg!(erlang::send_2(destination, message, process));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination.rs
@@ -1,0 +1,5 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;
+mod without_process;

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_different_process.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_locked;
+mod without_locked;

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_different_process/with_locked.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+#[test]
+fn with_atom_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_local_reference_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_empty_list_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        (crate::integer::small::MAX + 1).into_process(&process)
+    });
+}
+
+#[test]
+fn with_float_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|process| 0.0.into_process(&process));
+}
+
+#[test]
+fn with_local_pid_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::external_pid(1, 2, 3, &process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_tuple(&[], &process)
+    });
+}
+
+#[test]
+fn with_map_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_map(&[], &process)
+    });
+}
+
+#[test]
+fn with_heap_binary_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_binary(&[], &process)
+    });
+}
+
+#[test]
+fn with_subbinary_adds_heap_message_to_mailbox_and_returns_message() {
+    with_adds_heap_message_to_mailbox_and_returns_message(|process| bitstring!(1 :: 1, &process));
+}
+
+fn with_adds_heap_message_to_mailbox_and_returns_message<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process(|process| {
+        let different_process = process::local::new();
+        let destination = different_process.pid;
+
+        let _different_process_heap_lock = different_process.heap.lock().unwrap();
+
+        let message = message(process);
+
+        assert_eq!(erlang::send_2(destination, message, process), Ok(message));
+
+        assert!(different_process
+            .mailbox
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|mailbox_message| match mailbox_message {
+                Message::Heap {
+                    message: heap_message,
+                    ..
+                } => heap_message == &message,
+                _ => false,
+            }))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_different_process/without_locked.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+#[test]
+fn with_atom_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_big_integer_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        (crate::integer::small::MAX + 1).into_process(&process)
+    });
+}
+
+#[test]
+fn with_float_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        0.0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_local_pid_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|_| {
+        Term::local_pid(0, 1).unwrap()
+    });
+}
+
+#[test]
+fn with_external_pid_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::external_pid(1, 2, 3, &process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_tuple(&[], &process)
+    });
+}
+
+#[test]
+fn with_map_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_map(&[], &process)
+    });
+}
+
+#[test]
+fn with_heap_binary_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_binary(&[], &process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(
+        |process| bitstring!(1 :: 1, &process),
+    );
+}
+
+fn with_message_adds_process_message_to_mailbox_and_returns_message<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process(|process| {
+        let different_process = process::local::new();
+        let destination = different_process.pid;
+        let message = message(process);
+
+        assert_eq!(erlang::send_2(destination, message, process), Ok(message));
+
+        assert!(different_process
+            .mailbox
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|mailbox_message| match mailbox_message {
+                Message::Process(process_message) => process_message == &message,
+                _ => false,
+            }))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_same_process.rs
@@ -1,0 +1,109 @@
+use super::*;
+
+#[test]
+fn with_atom_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_big_integer_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        (crate::integer::small::MAX + 1).into_process(&process)
+    });
+}
+
+#[test]
+fn with_float_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        0.0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_local_pid_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|_| {
+        Term::local_pid(0, 1).unwrap()
+    });
+}
+
+#[test]
+fn with_external_pid_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::external_pid(1, 2, 3, &process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_tuple(&[], &process)
+    });
+}
+
+#[test]
+fn with_map_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_map(&[], &process)
+    });
+}
+
+#[test]
+fn with_heap_binary_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_binary(&[], &process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(
+        |process| bitstring!(1 :: 1, &process),
+    );
+}
+
+fn with_message_adds_process_message_to_mailbox_and_returns_message<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process(|process| {
+        let destination = process.pid;
+        let message = message(process);
+
+        assert_eq!(erlang::send_2(destination, message, process), Ok(message));
+
+        assert!(process.mailbox.lock().unwrap().iter().any(
+            |mailbox_message| match mailbox_message {
+                Message::Process(process_message) => process_message == &message,
+                _ => false,
+            }
+        ))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/without_process.rs
@@ -1,0 +1,80 @@
+use super::*;
+
+#[test]
+fn with_atom_message_returns_message() {
+    with_message_returns_message(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_local_reference_message_returns_message() {
+    with_message_returns_message(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_empty_list_message_returns_message() {
+    with_message_returns_message(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_returns_message() {
+    with_message_returns_message(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_message_returns_message() {
+    with_message_returns_message(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_message_returns_message() {
+    with_message_returns_message(|process| (crate::integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_float_message_returns_message() {
+    with_message_returns_message(|process| 0.0.into_process(&process));
+}
+
+#[test]
+fn with_local_pid_message_returns_message() {
+    with_message_returns_message(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_message_returns_message() {
+    with_message_returns_message(|process| Term::external_pid(1, 2, 3, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_message_returns_message() {
+    with_message_returns_message(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_message_returns_message() {
+    with_message_returns_message(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_heap_binary_message_returns_message() {
+    with_message_returns_message(|process| Term::slice_to_binary(&[], &process));
+}
+
+#[test]
+fn with_subbinary_message_returns_message() {
+    with_message_returns_message(|process| bitstring!(1 :: 1, &process));
+}
+
+fn with_message_returns_message<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process(|process| {
+        let destination = process::identifier::local::next();
+        let message = message(process);
+
+        assert_eq!(erlang::send_2(destination, message, process), Ok(message));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination.rs
@@ -1,0 +1,13 @@
+use super::*;
+
+mod with_arity_2;
+
+#[test]
+fn without_arity_2_errors_badarg() {
+    with_process(|process| {
+        let destination = Term::slice_to_tuple(&[], process);
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::send_2(destination, message, process))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+mod with_atom_name;
+
+#[test]
+fn with_local_reference_name_errors_badarg() {
+    with_name_errors_badarg(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_empty_list_name_errors_badarg() {
+    with_name_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_name_errors_badarg() {
+    with_name_errors_badarg(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_name_errors_badarg() {
+    with_name_errors_badarg(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_name_errors_badarg() {
+    with_name_errors_badarg(|process| (crate::integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_float_name_errors_badarg() {
+    with_name_errors_badarg(|process| 0.0.into_process(&process));
+}
+
+#[test]
+fn with_local_pid_name_errors_badarg() {
+    with_name_errors_badarg(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_name_errors_badarg() {
+    with_name_errors_badarg(|process| Term::external_pid(1, 2, 3, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_name_errors_badarg() {
+    with_name_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_name_errors_badarg() {
+    with_name_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_heap_binary_name_errors_badarg() {
+    with_name_errors_badarg(|process| Term::slice_to_binary(&[], &process));
+}
+
+#[test]
+fn with_subbinary_name_errors_badarg() {
+    with_name_errors_badarg(|process| bitstring!(1 :: 1, &process));
+}
+
+fn with_name_errors_badarg<N>(name: N)
+where
+    N: FnOnce(&Process) -> Term,
+{
+    with_process(|process| {
+        let destination = Term::slice_to_tuple(&[name(process), erlang::node_0()], process);
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::send_2(destination, message, process));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+mod with_atom_node;
+
+#[test]
+fn with_local_reference_name_errors_badarg() {
+    with_name_errors_badarg(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_empty_list_name_errors_badarg() {
+    with_name_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_name_errors_badarg() {
+    with_name_errors_badarg(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_name_errors_badarg() {
+    with_name_errors_badarg(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_name_errors_badarg() {
+    with_name_errors_badarg(|process| (crate::integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_float_name_errors_badarg() {
+    with_name_errors_badarg(|process| 0.0.into_process(&process));
+}
+
+#[test]
+fn with_local_pid_name_errors_badarg() {
+    with_name_errors_badarg(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_name_errors_badarg() {
+    with_name_errors_badarg(|process| Term::external_pid(1, 2, 3, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_name_errors_badarg() {
+    with_name_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_name_errors_badarg() {
+    with_name_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_heap_binary_name_errors_badarg() {
+    with_name_errors_badarg(|process| Term::slice_to_binary(&[], &process));
+}
+
+#[test]
+fn with_subbinary_name_errors_badarg() {
+    with_name_errors_badarg(|process| bitstring!(1 :: 1, &process));
+}
+
+fn with_name_errors_badarg<N>(node: N)
+where
+    N: FnOnce(&Process) -> Term,
+{
+    with_process(|process| {
+        let destination = Term::slice_to_tuple(&[registered_name(), node(process)], process);
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::send_2(destination, message, process));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_different_node;
+mod with_same_node;

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_different_node.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_different_node.rs
@@ -1,0 +1,108 @@
+use super::*;
+
+#[test]
+fn with_atom_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_local_reference_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_empty_list_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|process| {
+        (crate::integer::small::MAX + 1).into_process(&process)
+    });
+}
+
+#[test]
+fn with_float_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|process| 0.0.into_process(&process));
+}
+
+#[test]
+fn with_local_pid_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|process| Term::external_pid(1, 2, 3, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_heap_binary_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|process| Term::slice_to_binary(&[], &process));
+}
+
+#[test]
+fn with_subbinary_message_panics_unimplemented() {
+    with_message_panics_unimplemented(|process| bitstring!(1 :: 1, &process));
+}
+
+fn with_message_panics_unimplemented<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let name = registered_name();
+
+        assert_eq!(
+            erlang::register_2(name, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let destination = Term::slice_to_tuple(
+            &[
+                name,
+                Term::str_to_atom("node@example.com", DoNotCare).unwrap(),
+            ],
+            &process_arc,
+        );
+        let message = message(&process_arc);
+
+        let result =
+            std::panic::catch_unwind(|| erlang::send_2(destination, message, &process_arc));
+
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+
+        assert_eq!(
+            err.downcast_ref::<String>()
+                .map(|e| &**e)
+                .or_else(|| err.downcast_ref::<&'static str>().map(|e| *e))
+                .unwrap(),
+            "not yet implemented: distribution"
+        );
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod registered;
+mod unregistered;

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_locked;
+mod without_locked;

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/with_locked.rs
@@ -1,0 +1,128 @@
+use super::*;
+
+#[test]
+fn with_atom_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_big_integer_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        (crate::integer::small::MAX + 1).into_process(&process)
+    });
+}
+
+#[test]
+fn with_float_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        0.0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_local_pid_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|_| {
+        Term::local_pid(0, 1).unwrap()
+    });
+}
+
+#[test]
+fn with_external_pid_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::external_pid(1, 2, 3, &process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_tuple(&[], &process)
+    });
+}
+
+#[test]
+fn with_map_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_map(&[], &process)
+    });
+}
+
+#[test]
+fn with_heap_binary_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_binary(&[], &process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_adds_heap_message_to_mailbox_and_returns_message() {
+    with_message_adds_heap_message_to_mailbox_and_returns_message(
+        |process| bitstring!(1 :: 1, &process),
+    );
+}
+
+fn with_message_adds_heap_message_to_mailbox_and_returns_message<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let different_process = process::local::new();
+        let name = registered_name();
+
+        assert_eq!(
+            erlang::register_2(name, different_process.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let _different_process_heap_lock = different_process.heap.lock().unwrap();
+
+        let destination = Term::slice_to_tuple(&[name, erlang::node_0()], &process_arc);
+        let message = message(&process_arc);
+
+        assert_eq!(
+            erlang::send_2(destination, message, &process_arc),
+            Ok(message)
+        );
+
+        assert!(different_process
+            .mailbox
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|mailbox_message| match mailbox_message {
+                Message::Heap {
+                    message: heap_message,
+                    ..
+                } => heap_message == &message,
+                _ => false,
+            }))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
@@ -1,0 +1,123 @@
+use super::*;
+
+#[test]
+fn with_atom_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_big_integer_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        (crate::integer::small::MAX + 1).into_process(&process)
+    });
+}
+
+#[test]
+fn with_float_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        0.0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_local_pid_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|_| {
+        Term::local_pid(0, 1).unwrap()
+    });
+}
+
+#[test]
+fn with_external_pid_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::external_pid(1, 2, 3, &process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_tuple(&[], &process)
+    });
+}
+
+#[test]
+fn with_map_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_map(&[], &process)
+    });
+}
+
+#[test]
+fn with_heap_binary_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_binary(&[], &process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(
+        |process| bitstring!(1 :: 1, &process),
+    );
+}
+
+fn with_message_adds_process_message_to_mailbox_and_returns_message<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let different_process = process::local::new();
+        let name = registered_name();
+
+        assert_eq!(
+            erlang::register_2(name, different_process.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let destination = Term::slice_to_tuple(&[name, erlang::node_0()], &process_arc);
+        let message = message(&process_arc);
+
+        assert_eq!(
+            erlang::send_2(destination, message, &process_arc),
+            Ok(message)
+        );
+
+        assert!(different_process
+            .mailbox
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|mailbox_message| match mailbox_message {
+                Message::Process(process_message) => process_message == &message,
+                _ => false,
+            }))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
@@ -1,0 +1,122 @@
+use super::*;
+
+#[test]
+fn with_atom_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::local_reference(&process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_big_integer_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        (crate::integer::small::MAX + 1).into_process(&process)
+    });
+}
+
+#[test]
+fn with_float_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        0.0.into_process(&process)
+    });
+}
+
+#[test]
+fn with_local_pid_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|_| {
+        Term::local_pid(0, 1).unwrap()
+    });
+}
+
+#[test]
+fn with_external_pid_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::external_pid(1, 2, 3, &process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_tuple(&[], &process)
+    });
+}
+
+#[test]
+fn with_map_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_map(&[], &process)
+    });
+}
+
+#[test]
+fn with_heap_binary_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
+        Term::slice_to_binary(&[], &process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_adds_process_message_to_mailbox_and_returns_message() {
+    with_message_adds_process_message_to_mailbox_and_returns_message(
+        |process| bitstring!(1 :: 1, &process),
+    );
+}
+
+fn with_message_adds_process_message_to_mailbox_and_returns_message<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let name = registered_name();
+
+        assert_eq!(
+            erlang::register_2(name, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let destination = Term::slice_to_tuple(&[name, erlang::node_0()], &process_arc);
+        let message = message(&process_arc);
+
+        assert_eq!(
+            erlang::send_2(destination, message, &process_arc),
+            Ok(message)
+        );
+
+        assert!(process_arc
+            .mailbox
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|mailbox_message| match mailbox_message {
+                Message::Process(process_message) => process_message == &message,
+                _ => false,
+            }))
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/unregistered.rs
@@ -1,0 +1,80 @@
+use super::*;
+
+#[test]
+fn with_atom_message_returns_message() {
+    with_message_returns_message(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_local_reference_message_returns_message() {
+    with_message_returns_message(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_empty_list_message_returns_message() {
+    with_message_returns_message(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_returns_message() {
+    with_message_returns_message(|process| {
+        Term::cons(0.into_process(&process), 1.into_process(&process), &process)
+    });
+}
+
+#[test]
+fn with_small_integer_message_returns_message() {
+    with_message_returns_message(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_message_returns_message() {
+    with_message_returns_message(|process| (crate::integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_float_message_returns_message() {
+    with_message_returns_message(|process| 0.0.into_process(&process));
+}
+
+#[test]
+fn with_local_pid_message_returns_message() {
+    with_message_returns_message(|_| Term::local_pid(0, 1).unwrap());
+}
+
+#[test]
+fn with_external_pid_message_returns_message() {
+    with_message_returns_message(|process| Term::external_pid(1, 2, 3, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_message_returns_message() {
+    with_message_returns_message(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_message_returns_message() {
+    with_message_returns_message(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_heap_binary_message_returns_message() {
+    with_message_returns_message(|process| Term::slice_to_binary(&[], &process));
+}
+
+#[test]
+fn with_subbinary_message_returns_message() {
+    with_message_returns_message(|process| bitstring!(1 :: 1, &process));
+}
+
+fn with_message_returns_message<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process(|process| {
+        let destination = Term::slice_to_tuple(&[registered_name(), erlang::node_0()], process);
+        let message = message(process);
+
+        assert_badarg!(erlang::send_2(destination, message, process));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/unregister_1/with_atom_name/with_registered_name.rs
+++ b/lumen_runtime/src/otp/erlang/tests/unregister_1/with_atom_name/with_registered_name.rs
@@ -11,7 +11,7 @@ fn with_same_process_returns_true() {
             Ok(true.into())
         );
 
-        assert_eq!(*process_arc.registered_name.lock().unwrap(), Some(name));
+        assert_eq!(*process_arc.registered_name.read().unwrap(), Some(name));
         assert_eq!(
             registry::RW_LOCK_REGISTERED_BY_NAME
                 .read()
@@ -22,7 +22,7 @@ fn with_same_process_returns_true() {
 
         assert_eq!(erlang::unregister_1(name), Ok(true.into()));
 
-        assert_eq!(*process_arc.registered_name.lock().unwrap(), None);
+        assert_eq!(*process_arc.registered_name.read().unwrap(), None);
         assert_eq!(
             registry::RW_LOCK_REGISTERED_BY_NAME
                 .read()
@@ -46,9 +46,9 @@ fn with_different_process_returns_true() {
             Ok(true.into())
         );
 
-        assert_eq!(*process_arc.registered_name.lock().unwrap(), None);
+        assert_eq!(*process_arc.registered_name.read().unwrap(), None);
         assert_eq!(
-            *another_process_arc.registered_name.lock().unwrap(),
+            *another_process_arc.registered_name.read().unwrap(),
             Some(name)
         );
         assert_eq!(
@@ -61,7 +61,7 @@ fn with_different_process_returns_true() {
 
         assert_eq!(erlang::unregister_1(name), Ok(true.into()));
 
-        assert_eq!(*another_process_arc.registered_name.lock().unwrap(), None);
+        assert_eq!(*another_process_arc.registered_name.read().unwrap(), None);
         assert_eq!(
             registry::RW_LOCK_REGISTERED_BY_NAME
                 .read()

--- a/lumen_runtime/src/process.rs
+++ b/lumen_runtime/src/process.rs
@@ -1,19 +1,19 @@
 ///! The memory specific to a process in the VM.
 #[cfg(test)]
 use std::fmt::{self, Debug};
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 
-use im::hashmap::HashMap;
 use num_bigint::BigInt;
 
-use liblumen_arena::TypedArena;
-
-use crate::binary::{heap, sub, Binary};
+use crate::binary::{sub, Binary};
 use crate::exception::Exception;
 use crate::float::Float;
+use crate::heap::{CloneIntoHeap, Heap};
 use crate::integer::{self, big};
 use crate::list::Cons;
+use crate::mailbox::Mailbox;
 use crate::map::Map;
+use crate::message::Message;
 use crate::reference;
 use crate::term::Term;
 use crate::tuple::Tuple;
@@ -23,17 +23,9 @@ pub mod local;
 
 pub struct Process {
     pub pid: Term,
-    pub registered_name: Mutex<Option<Term>>,
-    big_integer_arena: Mutex<TypedArena<big::Integer>>,
-    byte_arena: Mutex<TypedArena<u8>>,
-    cons_arena: Mutex<TypedArena<Cons>>,
-    external_pid_arena: Mutex<TypedArena<identifier::External>>,
-    float_arena: Mutex<TypedArena<Float>>,
-    heap_binary_arena: Mutex<TypedArena<heap::Binary>>,
-    map_arena: Mutex<TypedArena<Map>>,
-    local_reference_arena: Mutex<TypedArena<reference::local::Reference>>,
-    subbinary_arena: Mutex<TypedArena<sub::Binary>>,
-    term_arena: Mutex<TypedArena<Term>>,
+    pub registered_name: RwLock<Option<Term>>,
+    pub heap: Mutex<Heap>,
+    pub mailbox: Mutex<Mailbox>,
 }
 
 impl Process {
@@ -42,29 +34,19 @@ impl Process {
         Process {
             pid: identifier::local::next(),
             registered_name: Default::default(),
-            big_integer_arena: Default::default(),
-            byte_arena: Default::default(),
-            cons_arena: Default::default(),
-            external_pid_arena: Default::default(),
-            float_arena: Default::default(),
-            heap_binary_arena: Default::default(),
-            map_arena: Default::default(),
-            local_reference_arena: Default::default(),
-            subbinary_arena: Default::default(),
-            term_arena: Default::default(),
+            heap: Default::default(),
+            mailbox: Default::default(),
         }
     }
 
     pub fn alloc_term_slice(&self, slice: &[Term]) -> *const Term {
-        self.term_arena.lock().unwrap().alloc_slice(slice).as_ptr()
+        self.heap.lock().unwrap().alloc_term_slice(slice)
     }
 
     /// Combines the two `Term`s into a list `Term`.  The list is only a proper list if the `tail`
     /// is a list `Term` (`Term.tag` is `List`) or empty list (`Term.tag` is `EmptyList`).
     pub fn cons(&self, head: Term, tail: Term) -> &'static Cons {
-        let pointer = self.cons_arena.lock().unwrap().alloc(Cons::new(head, tail)) as *const Cons;
-
-        unsafe { &*pointer }
+        self.heap.lock().unwrap().cons(head, tail)
     }
 
     pub fn external_pid(
@@ -73,53 +55,53 @@ impl Process {
         number: usize,
         serial: usize,
     ) -> &'static identifier::External {
-        let pointer = self
-            .external_pid_arena
-            .lock()
-            .unwrap()
-            .alloc(identifier::External::new(node, number, serial))
-            as *const identifier::External;
-
-        unsafe { &*pointer }
+        self.heap.lock().unwrap().external_pid(node, number, serial)
     }
 
     pub fn f64_to_float(&self, f: f64) -> &'static Float {
-        let pointer = self.float_arena.lock().unwrap().alloc(Float::new(f)) as *const Float;
-
-        unsafe { &*pointer }
+        self.heap.lock().unwrap().f64_to_float(f)
     }
 
     pub fn local_reference(&self) -> &'static reference::local::Reference {
-        let pointer = self
-            .local_reference_arena
-            .lock()
-            .unwrap()
-            .alloc(reference::local::Reference::next())
-            as *const reference::local::Reference;
-
-        unsafe { &*pointer }
+        self.heap.lock().unwrap().local_reference()
     }
 
     #[cfg(test)]
     pub fn number_to_local_reference(&self, number: u64) -> &'static reference::local::Reference {
-        let pointer = self
-            .local_reference_arena
-            .lock()
-            .unwrap()
-            .alloc(reference::local::Reference::new(number))
-            as *const reference::local::Reference;
-
-        unsafe { &*pointer }
+        self.heap.lock().unwrap().number_to_local_reference(number)
     }
 
-    pub fn num_bigint_big_in_to_big_integer(&self, big_int: BigInt) -> &'static big::Integer {
-        let pointer = self
-            .big_integer_arena
+    pub fn num_bigint_big_to_big_integer(&self, big_int: BigInt) -> &'static big::Integer {
+        self.heap
             .lock()
             .unwrap()
-            .alloc(big::Integer::new(big_int)) as *const big::Integer;
+            .num_bigint_big_to_big_integer(big_int)
+    }
 
-        unsafe { &*pointer }
+    pub fn send_from_self(&self, message: Term) {
+        self.mailbox.lock().unwrap().push(Message::Process(message));
+    }
+
+    pub fn send_from_other(&self, message: Term) {
+        match self.heap.try_lock() {
+            Ok(ref mut destination_heap) => {
+                let destination_message = message.clone_into_heap(destination_heap);
+
+                self.mailbox
+                    .lock()
+                    .unwrap()
+                    .push(Message::Process(destination_message));
+            }
+            Err(_) => {
+                let heap: Heap = Default::default();
+                let heap_message = message.clone_into_heap(&heap);
+
+                self.mailbox.lock().unwrap().push(Message::Heap {
+                    heap,
+                    message: heap_message,
+                });
+            }
+        }
     }
 
     pub fn subbinary(
@@ -130,69 +112,29 @@ impl Process {
         byte_count: usize,
         bit_count: u8,
     ) -> &'static sub::Binary {
-        let pointer = self.subbinary_arena.lock().unwrap().alloc(sub::Binary::new(
+        self.heap.lock().unwrap().subbinary(
             original,
             byte_offset,
             bit_offset,
             byte_count,
             bit_count,
-        )) as *const sub::Binary;
-
-        unsafe { &*pointer }
+        )
     }
 
-    pub fn slice_to_binary(&self, slice: &[u8]) -> Binary {
-        // TODO use reference counted binaries for bytes.len() > 64
-        let heap_binary = self.slice_to_heap_binary(slice);
-
-        Binary::Heap(heap_binary)
+    pub fn slice_to_binary(&self, slice: &[u8]) -> Binary<'static> {
+        self.heap.lock().unwrap().slice_to_binary(slice)
     }
 
-    pub fn slice_to_map(&self, slice: &[(Term, Term)]) -> &Map {
-        let mut inner: HashMap<Term, Term> = HashMap::new();
-
-        for (key, value) in slice {
-            inner.insert(key.clone(), value.clone());
-        }
-
-        let pointer = self.map_arena.lock().unwrap().alloc(Map::new(inner)) as *const Map;
-
-        unsafe { &*pointer }
+    pub fn slice_to_map(&self, slice: &[(Term, Term)]) -> &'static Map {
+        self.heap.lock().unwrap().slice_to_map(slice)
     }
 
-    pub fn slice_to_tuple(&self, slice: &[Term]) -> &Tuple {
-        Tuple::from_slice(slice, &self)
+    pub fn slice_to_tuple(&self, slice: &[Term]) -> &'static Tuple {
+        self.heap.lock().unwrap().slice_to_tuple(slice)
     }
 
     pub fn u64_to_local_reference(&self, number: u64) -> &'static reference::local::Reference {
-        let pointer = self
-            .local_reference_arena
-            .lock()
-            .unwrap()
-            .alloc(reference::local::Reference::new(number))
-            as *const reference::local::Reference;
-
-        unsafe { &*pointer }
-    }
-
-    // Private
-
-    fn slice_to_heap_binary(&self, bytes: &[u8]) -> &'static heap::Binary {
-        let locked_byte_arena = self.byte_arena.lock().unwrap();
-
-        let arena_bytes: &[u8] = if bytes.len() != 0 {
-            locked_byte_arena.alloc_slice(bytes)
-        } else {
-            &[]
-        };
-
-        let pointer = self
-            .heap_binary_arena
-            .lock()
-            .unwrap()
-            .alloc(heap::Binary::new(arena_bytes)) as *const heap::Binary;
-
-        unsafe { &*pointer }
+        self.heap.lock().unwrap().u64_to_local_reference(number)
     }
 }
 

--- a/lumen_runtime/src/process/identifier.rs
+++ b/lumen_runtime/src/process/identifier.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering::{self, *};
 use std::hash::{Hash, Hasher};
 
+use crate::heap::{CloneIntoHeap, Heap};
 use crate::term::{Tag, Tag::*, Term};
 
 // Not really test-only, but dead otherwise for now.
@@ -33,6 +34,12 @@ impl External {
             serial,
             number,
         }
+    }
+}
+
+impl CloneIntoHeap for &'static External {
+    fn clone_into_heap(&self, heap: &Heap) -> &'static External {
+        heap.external_pid(self.node, self.number, self.serial)
     }
 }
 

--- a/lumen_runtime/src/reference/local.rs
+++ b/lumen_runtime/src/reference/local.rs
@@ -1,6 +1,7 @@
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use crate::heap::{CloneIntoHeap, Heap};
 use crate::term::{Tag::LocalReference, Term};
 
 pub struct Reference {
@@ -21,6 +22,12 @@ impl Reference {
 
     pub fn next() -> Reference {
         Self::new(COUNT.fetch_add(1, Ordering::SeqCst))
+    }
+}
+
+impl CloneIntoHeap for &'static Reference {
+    fn clone_into_heap(&self, heap: &Heap) -> &'static Reference {
+        heap.u64_to_local_reference(self.number)
     }
 }
 


### PR DESCRIPTION
The heap fragment system from BEAM is implemented, but because `receive` is not implemented yet, the mailbox is a single `Vec` instead of separated seen and unseen collection as in BEAM.

It's not listed as a BIF because it's an internal VM one, so in addition to the `:erlang` BIFs which cover sends (and `!/2` because it is just `send/2`), I will also need to implement `receive` and its accompanying tracking of seen and unseen.  For my `send/2` tests I'm directly checking the mailbox as that allows me to tell that I proper created a process heap message (`Message::Process`) or a heap fragment message (`Message::Heap`).

# Changelog
## Enhancements
* `:erlang.send/2` and `!/2` infix operator.  (All uses of `!/2` should just call `erlang::send_2`.)
  *  To allow for heap fragments, the arenas that were in `Process` have moved into a separate `Heap` struct that can be used in a `Process` or independently to represent heap fragments.
  * In a `Process`, the `heap` is protected by a `Mutex` and the individual `Mutex`es on arenas is removed.  This more closely mirrors the "main lock" used in BEAM and prevents the order of arena locks being taken in the wrong order.
  * Having `Heap` own the arenas means some of the internal APIs now take `&Heap` instead of `&Process`, but this also makes those APIs compatible with both `Process`es and `Heap`s for heap fragments.