### PR TITLE
erlang::start_timer_3

### DIFF
--- a/lumen_runtime/src/heap.rs
+++ b/lumen_runtime/src/heap.rs
@@ -1,3 +1,5 @@
+use std::fmt::{self, Debug};
+
 use im::hashmap::HashMap;
 use num_bigint::BigInt;
 
@@ -158,6 +160,12 @@ impl Heap {
 
 pub trait CloneIntoHeap {
     fn clone_into_heap(&self, heap: &Heap) -> Self;
+}
+
+impl Debug for Heap {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Heap {{ ... }}")
+    }
 }
 
 impl Default for Heap {

--- a/lumen_runtime/src/lib.rs
+++ b/lumen_runtime/src/lib.rs
@@ -53,6 +53,8 @@ mod stacktrace;
 mod system;
 mod term;
 mod time;
+// Public so that external code can all `timer::expire` to expire timers
+pub mod timer;
 mod tuple;
 
 use self::config::Config;

--- a/lumen_runtime/src/map.rs
+++ b/lumen_runtime/src/map.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering::{self, *};
 
-use im::hashmap::HashMap;
+use im::hashmap::{HashMap, Iter};
 
 use crate::atom::Existence::DoNotCare;
 use crate::exception::Result;
@@ -35,6 +35,10 @@ impl Map {
                 Err(error!(reason))
             }
         }
+    }
+
+    pub fn iter(&self) -> Iter<Term, Term> {
+        self.inner.iter()
     }
 
     pub fn is_key(&self, key: Term) -> bool {

--- a/lumen_runtime/src/message.rs
+++ b/lumen_runtime/src/message.rs
@@ -1,6 +1,7 @@
 use crate::heap;
 use crate::term::Term;
 
+#[cfg_attr(test, derive(Debug))]
 pub enum Message {
     /// A message whose `Term` is allocated inside the receiving `Process`'s `Heap`.
     Process(Term),

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_different_process/without_locked.rs
@@ -103,14 +103,6 @@ where
             Ok(message)
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_same_process.rs
@@ -108,14 +108,6 @@ where
             Ok(message)
         );
 
-        assert!(process_arc
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&process_arc, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_different_process/without_locked.rs
@@ -100,14 +100,6 @@ where
 
         assert_eq!(erlang::send_2(destination, message, process), Ok(message));
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_same_process.rs
@@ -99,11 +99,6 @@ where
 
         assert_eq!(erlang::send_2(destination, message, process), Ok(message));
 
-        assert!(process.mailbox.lock().unwrap().iter().any(
-            |mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }
-        ))
+        assert!(has_process_message(process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
@@ -110,14 +110,6 @@ where
             Ok(message)
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
@@ -109,14 +109,6 @@ where
             Ok(message)
         );
 
-        assert!(process_arc
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&process_arc, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_atom_destination/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_atom_destination/registered/with_different_process/without_locked.rs
@@ -98,14 +98,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_atom_destination/registered/with_same_process.rs
@@ -105,14 +105,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(process_arc
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&process_arc, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_local_pid_destination/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_local_pid_destination/with_different_process/without_locked.rs
@@ -100,14 +100,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_local_pid_destination/with_same_process.rs
@@ -99,11 +99,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(process.mailbox.lock().unwrap().iter().any(
-            |mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }
-        ))
+        assert!(has_process_message(process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
@@ -107,14 +107,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
@@ -106,14 +106,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(process_arc
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&process_arc, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_atom_destination/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_atom_destination/registered/with_different_process/without_locked.rs
@@ -98,14 +98,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_atom_destination/registered/with_same_process.rs
@@ -105,14 +105,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(process_arc
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&process_arc, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_local_pid_destination/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_local_pid_destination/with_different_process/without_locked.rs
@@ -100,14 +100,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_local_pid_destination/with_same_process.rs
@@ -99,11 +99,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(process.mailbox.lock().unwrap().iter().any(
-            |mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }
-        ))
+        assert!(has_process_message(process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
@@ -107,14 +107,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
@@ -106,14 +106,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(process_arc
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&process_arc, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_atom_destination/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_atom_destination/registered/with_different_process/without_locked.rs
@@ -98,14 +98,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_atom_destination/registered/with_same_process.rs
@@ -105,14 +105,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(process_arc
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&process_arc, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_local_pid_destination/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_local_pid_destination/with_different_process/without_locked.rs
@@ -100,14 +100,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_local_pid_destination/with_same_process.rs
@@ -99,11 +99,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(process.mailbox.lock().unwrap().iter().any(
-            |mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }
-        ))
+        assert!(has_process_message(process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
@@ -107,14 +107,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
@@ -106,14 +106,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(process_arc
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&process_arc, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_atom_destination/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_atom_destination/registered/with_different_process/without_locked.rs
@@ -98,14 +98,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_atom_destination/registered/with_same_process.rs
@@ -105,14 +105,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(process_arc
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&process_arc, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_local_pid_destination/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_local_pid_destination/with_different_process/without_locked.rs
@@ -100,14 +100,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_local_pid_destination/with_same_process.rs
@@ -99,11 +99,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(process.mailbox.lock().unwrap().iter().any(
-            |mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }
-        ))
+        assert!(has_process_message(process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
@@ -107,14 +107,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(different_process
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&different_process, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
@@ -106,14 +106,6 @@ where
             Ok(Term::str_to_atom("ok", DoNotCare).unwrap())
         );
 
-        assert!(process_arc
-            .mailbox
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|mailbox_message| match mailbox_message {
-                Message::Process(process_message) => process_message == &message,
-                _ => false,
-            }))
+        assert!(has_process_message(&process_arc, message));
     })
 }

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3.rs
@@ -1,0 +1,81 @@
+use super::*;
+
+mod with_small_integer_time;
+
+#[test]
+fn with_float_time_errors_badarg() {
+    with_time_errors_badarg(|process| 1.0.into_process(&process));
+}
+
+// BigInt is not tested because it would take too long and would always count as `long_term` for the
+// super shot soon and later wheel sizes used for `cfg(test)`
+
+#[test]
+fn with_atom_time_errors_badarg() {
+    with_time_errors_badarg(|_| Term::str_to_atom("atom", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_time_errors_badarg() {
+    with_time_errors_badarg(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_local_pid_time_errors_badarg() {
+    with_time_errors_badarg(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_time_errors_badarg() {
+    with_time_errors_badarg(|process| Term::external_pid(1, 0, 0, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_time_errors_badarg() {
+    with_time_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_time_errors_badarg() {
+    with_time_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_empty_list_time_errors_badarg() {
+    with_time_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_time_errors_badarg() {
+    with_time_errors_badarg(|process| list_term(&process));
+}
+
+#[test]
+fn with_heap_binary_time_errors_badarg() {
+    with_time_errors_badarg(|process| Term::slice_to_binary(&[1], &process));
+}
+
+#[test]
+fn with_subbinary_time_errors_badarg() {
+    with_time_errors_badarg(|process| {
+        let original = Term::slice_to_binary(&[0, 1], &process);
+        Term::subbinary(original, 1, 0, 1, 0, &process)
+    });
+}
+
+fn with_time_errors_badarg<T>(time: T)
+where
+    T: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = process_arc.pid;
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::start_timer_3(
+            time(&process_arc),
+            destination,
+            message,
+            process_arc
+        ));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time.rs
@@ -1,0 +1,6 @@
+use super::*;
+
+mod at_once;
+mod later;
+mod long_term;
+mod soon;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+mod with_atom_destination;
+mod with_local_pid_destination;
+
+#[test]
+fn with_small_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_float_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 1.0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| (integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_local_reference_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_external_pid_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::external_pid(1, 0, 0, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_empty_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| list_term(&process));
+}
+
+#[test]
+fn with_heap_binary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_binary(&[1], &process));
+}
+
+#[test]
+fn with_subbinary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| {
+        let original = Term::slice_to_binary(&[0, 1], &process);
+        Term::subbinary(original, 1, 0, 1, 0, &process)
+    });
+}
+
+fn milliseconds() -> u64 {
+    timer::at_once_milliseconds()
+}
+
+fn with_destination_errors_badarg<D>(destination: D)
+where
+    D: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let time = milliseconds().into_process(&process_arc);
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::start_timer_3(
+            time,
+            destination(&process_arc),
+            message,
+            process_arc
+        ));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod registered;
+mod unregistered;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/registered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/registered.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
@@ -1,0 +1,125 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination_process_arc = process::local::new();
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(
+                destination,
+                destination_process_arc.pid,
+                process_arc.clone()
+            ),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&destination_process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination.rs
@@ -1,0 +1,5 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;
+mod without_process;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination/with_different_process.rs
@@ -1,0 +1,117 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination_process_arc = process::local::new();
+        let destination = destination_process_arc.pid;
+
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&destination_process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination/with_same_process.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination = process_arc.pid;
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination/without_process.rs
@@ -1,0 +1,103 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| (integer::small::MAX + 1).into_process(process));
+}
+
+#[test]
+fn with_local_reference_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| Term::external_pid(1, 0, 0, process).unwrap());
+}
+
+#[test]
+fn with_tuple_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn does_not_panic_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = process::identifier::local::next();
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        // does not send to original process either
+        assert!(!has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+mod with_atom_destination;
+mod with_local_pid_destination;
+
+#[test]
+fn with_small_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_float_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 1.0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| (integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_local_reference_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_external_pid_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::external_pid(1, 0, 0, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_empty_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| list_term(&process));
+}
+
+#[test]
+fn with_heap_binary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_binary(&[1], &process));
+}
+
+#[test]
+fn with_subbinary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| {
+        let original = Term::slice_to_binary(&[0, 1], &process);
+        Term::subbinary(original, 1, 0, 1, 0, &process)
+    });
+}
+
+fn milliseconds() -> u64 {
+    timer::later_milliseconds()
+}
+
+fn with_destination_errors_badarg<D>(destination: D)
+where
+    D: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let time = milliseconds().into_process(&process_arc);
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::start_timer_3(
+            time,
+            destination(&process_arc),
+            message,
+            process_arc
+        ));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod registered;
+mod unregistered;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/registered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/registered.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
@@ -1,0 +1,125 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination_process_arc = process::local::new();
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(
+                destination,
+                destination_process_arc.pid,
+                process_arc.clone()
+            ),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&destination_process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/unregistered.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination.rs
@@ -1,0 +1,5 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;
+mod without_process;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination/with_different_process.rs
@@ -1,0 +1,117 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination_process_arc = process::local::new();
+        let destination = destination_process_arc.pid;
+
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&destination_process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination/with_same_process.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination = process_arc.pid;
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination/without_process.rs
@@ -1,0 +1,107 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_does_not_panic_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = process::identifier::local::next();
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        // does not send to original process either
+        assert!(!has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+mod with_atom_destination;
+mod with_local_pid_destination;
+
+#[test]
+fn with_small_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_float_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 1.0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| (integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_local_reference_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_external_pid_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::external_pid(1, 0, 0, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_empty_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| list_term(&process));
+}
+
+#[test]
+fn with_heap_binary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_binary(&[1], &process));
+}
+
+#[test]
+fn with_subbinary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| {
+        let original = Term::slice_to_binary(&[0, 1], &process);
+        Term::subbinary(original, 1, 0, 1, 0, &process)
+    });
+}
+
+fn milliseconds() -> u64 {
+    timer::long_term_milliseconds()
+}
+
+fn with_destination_errors_badarg<D>(destination: D)
+where
+    D: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let time = milliseconds().into_process(&process_arc);
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::start_timer_3(
+            time,
+            destination(&process_arc),
+            message,
+            process_arc
+        ));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod registered;
+mod unregistered;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/registered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/registered.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
@@ -1,0 +1,125 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination_process_arc = process::local::new();
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(
+                destination,
+                destination_process_arc.pid,
+                process_arc.clone()
+            ),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&destination_process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination.rs
@@ -1,0 +1,5 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;
+mod without_process;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination/with_different_process.rs
@@ -1,0 +1,117 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination_process_arc = process::local::new();
+        let destination = destination_process_arc.pid;
+
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&destination_process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination/with_same_process.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination = process_arc.pid;
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination/without_process.rs
@@ -1,0 +1,107 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_does_not_panic_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = process::identifier::local::next();
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        // does not send to original process either
+        assert!(!has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+mod with_atom_destination;
+mod with_local_pid_destination;
+
+#[test]
+fn with_small_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_float_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 1.0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| (integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_local_reference_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::local_reference(&process));
+}
+
+#[test]
+fn with_external_pid_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::external_pid(1, 0, 0, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_empty_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| list_term(&process));
+}
+
+#[test]
+fn with_heap_binary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_binary(&[1], &process));
+}
+
+#[test]
+fn with_subbinary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| {
+        let original = Term::slice_to_binary(&[0, 1], &process);
+        Term::subbinary(original, 1, 0, 1, 0, &process)
+    });
+}
+
+fn milliseconds() -> u64 {
+    timer::soon_milliseconds()
+}
+
+fn with_destination_errors_badarg<D>(destination: D)
+where
+    D: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let time = milliseconds().into_process(&process_arc);
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::start_timer_3(
+            time,
+            destination(&process_arc),
+            message,
+            process_arc
+        ));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod registered;
+mod unregistered;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/registered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/registered.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
@@ -1,0 +1,125 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination_process_arc = process::local::new();
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(
+                destination,
+                destination_process_arc.pid,
+                process_arc.clone()
+            ),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&destination_process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/unregistered.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination.rs
@@ -1,0 +1,5 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;
+mod without_process;

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination/with_different_process.rs
@@ -1,0 +1,117 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination_process_arc = process::local::new();
+        let destination = destination_process_arc.pid;
+
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&destination_process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination/with_same_process.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_tuple(&[], process)
+    });
+}
+
+#[test]
+fn with_map_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_map(&[], process)
+    });
+}
+
+#[test]
+fn with_empty_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::slice_to_binary(&[1], process)
+    });
+}
+
+#[test]
+fn with_subbinary_message_sends_timeout_message_when_timer_expires() {
+    with_message_sends_timeout_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_timeout_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination = process_arc.pid;
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination/without_process.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_does_not_panic_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::start_timer_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        let timeout_message = Term::slice_to_tuple(
+            &[
+                Term::str_to_atom("timeout", DoNotCare).unwrap(),
+                timer_reference,
+                message,
+            ],
+            &process_arc,
+        );
+
+        assert!(!has_message(&process_arc, timeout_message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, timeout_message));
+    })
+}

--- a/lumen_runtime/src/process.rs
+++ b/lumen_runtime/src/process.rs
@@ -1,5 +1,4 @@
 ///! The memory specific to a process in the VM.
-#[cfg(test)]
 use std::fmt::{self, Debug};
 use std::sync::{Mutex, RwLock};
 
@@ -78,6 +77,13 @@ impl Process {
             .num_bigint_big_to_big_integer(big_int)
     }
 
+    pub fn send_heap_message(&self, heap: Heap, message: Term) {
+        self.mailbox
+            .lock()
+            .unwrap()
+            .push(Message::Heap { heap, message });
+    }
+
     pub fn send_from_self(&self, message: Term) {
         self.mailbox.lock().unwrap().push(Message::Process(message));
     }
@@ -96,10 +102,7 @@ impl Process {
                 let heap: Heap = Default::default();
                 let heap_message = message.clone_into_heap(&heap);
 
-                self.mailbox.lock().unwrap().push(Message::Heap {
-                    heap,
-                    message: heap_message,
-                });
+                self.send_heap_message(heap, heap_message);
             }
         }
     }
@@ -138,7 +141,6 @@ impl Process {
     }
 }
 
-#[cfg(test)]
 impl Debug for Process {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.pid)

--- a/lumen_runtime/src/process/local.rs
+++ b/lumen_runtime/src/process/local.rs
@@ -4,14 +4,18 @@ use std::sync::{Arc, RwLock};
 use crate::process::Process;
 use crate::term::Term;
 
-lazy_static! {
-    static ref RW_LOCK_ARC_PROCESS_BY_PID: RwLock<HashMap<Term, Arc<Process>>> = Default::default();
-}
-
 pub fn pid_to_process(pid: Term) -> Option<Arc<Process>> {
     match RW_LOCK_ARC_PROCESS_BY_PID.read().unwrap().get(&pid) {
         Some(ref process_arc) => Some(Arc::clone(process_arc)),
         None => None,
+    }
+}
+
+pub fn pid_to_self_or_process(pid: Term, process_arc: &Arc<Process>) -> Option<Arc<Process>> {
+    if process_arc.pid.tagged == pid.tagged {
+        Some(process_arc.clone())
+    } else {
+        pid_to_process(pid)
     }
 }
 
@@ -30,6 +34,10 @@ pub fn new() -> Arc<Process> {
     }
 
     process_arc
+}
+
+lazy_static! {
+    static ref RW_LOCK_ARC_PROCESS_BY_PID: RwLock<HashMap<Term, Arc<Process>>> = Default::default();
 }
 
 #[cfg(test)]

--- a/lumen_runtime/src/reference/local.rs
+++ b/lumen_runtime/src/reference/local.rs
@@ -4,14 +4,16 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::heap::{CloneIntoHeap, Heap};
 use crate::term::{Tag::LocalReference, Term};
 
+pub type Number = u64;
+
 pub struct Reference {
     #[allow(dead_code)]
     header: Term,
-    pub number: u64,
+    number: Number,
 }
 
 impl Reference {
-    pub fn new(number: u64) -> Reference {
+    pub fn new(number: Number) -> Reference {
         Reference {
             header: Term {
                 tagged: LocalReference as usize,
@@ -22,6 +24,10 @@ impl Reference {
 
     pub fn next() -> Reference {
         Self::new(COUNT.fetch_add(1, Ordering::SeqCst))
+    }
+
+    pub fn number(&self) -> Number {
+        self.number
     }
 }
 

--- a/lumen_runtime/src/time/monotonic.rs
+++ b/lumen_runtime/src/time/monotonic.rs
@@ -5,6 +5,9 @@ use num_bigint::BigInt;
 use crate::time::convert;
 use crate::time::Unit::{self, *};
 
+// Must be at least a `u64` because `u32` is only ~49 days (`(1 << 32)`)
+pub type Milliseconds = u64;
+
 pub fn time(unit: Unit) -> BigInt {
     let duration = START.elapsed();
 
@@ -15,6 +18,10 @@ pub fn time(unit: Unit) -> BigInt {
         Nanosecond => duration.as_nanos().into(),
         _ => convert(duration.as_nanos().into(), Nanosecond, unit),
     }
+}
+
+pub fn time_in_milliseconds() -> Milliseconds {
+    START.elapsed().as_millis() as Milliseconds
 }
 
 lazy_static! {

--- a/lumen_runtime/src/timer.rs
+++ b/lumen_runtime/src/timer.rs
@@ -1,0 +1,488 @@
+use std::cell::RefCell;
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
+use std::ops::{Index, IndexMut};
+use std::rc::{self, Rc};
+use std::sync;
+
+use crate::atom::Existence::DoNotCare;
+use crate::heap::{self, CloneIntoHeap};
+use crate::process::Process;
+use crate::reference;
+use crate::registry::{self, Registered};
+use crate::term::Term;
+use crate::time::monotonic::{self, Milliseconds};
+
+pub fn start(
+    monotonic_time_milliseconds: Milliseconds,
+    destination: Destination,
+    process_message: Term,
+    process: &Process,
+) -> Term {
+    let reference = HIERARCHY.with(|thread_local_hierarchy| {
+        thread_local_hierarchy.borrow_mut().start(
+            monotonic_time_milliseconds,
+            destination,
+            process_message,
+            process,
+        )
+    });
+
+    Term::box_reference(reference)
+}
+
+/// Times out the timers for the thread that have timed out since the last time `timeout` was
+/// called.
+pub fn timeout() {
+    HIERARCHY.with(|thread_local_hierarchy| thread_local_hierarchy.borrow_mut().timeout());
+}
+
+#[derive(Clone, Debug)]
+pub enum Destination {
+    Name(Term),
+    Process(sync::Weak<Process>),
+}
+
+#[derive(Debug)]
+struct Timer {
+    // Can't be a `Boxed` `LocalReference` `Term` because those are boxed and the original Process
+    // could GC the unboxed `LocalReference` `Term`.
+    reference_number: u64,
+    monotonic_time_milliseconds: Milliseconds,
+    destination: Destination,
+    #[allow(dead_code)]
+    heap: heap::Heap,
+    message: Term,
+    position: Position,
+}
+
+impl Timer {
+    fn timeout(self) {
+        match &self.destination {
+            Destination::Name(ref name) => {
+                let readable_registry = registry::RW_LOCK_REGISTERED_BY_NAME.read().unwrap();
+
+                match readable_registry.get(name) {
+                    Some(Registered::Process(destination_process_arc)) => {
+                        let timeout_message = self.timeout_message();
+
+                        destination_process_arc.send_heap_message(self.heap, timeout_message);
+                    }
+                    None => (),
+                }
+            }
+            Destination::Process(destination_process_weak) => {
+                if let Some(destination_process_arc) = destination_process_weak.upgrade() {
+                    let timeout_message = self.timeout_message();
+
+                    destination_process_arc.send_heap_message(self.heap, timeout_message);
+                }
+            }
+        }
+    }
+
+    fn timeout_message(&self) -> Term {
+        let reference = self.heap.u64_to_local_reference(self.reference_number);
+        let reference_term = Term::box_reference(reference);
+
+        let tuple = self.heap.slice_to_tuple(&[
+            Term::str_to_atom("timeout", DoNotCare).unwrap(),
+            reference_term,
+            self.message,
+        ]);
+
+        Term::box_reference(tuple)
+    }
+}
+
+impl Clone for Timer {
+    fn clone(&self) -> Timer {
+        let cloned_heap: heap::Heap = Default::default();
+        let cloned_heap_message = self.message.clone_into_heap(&cloned_heap);
+
+        Timer {
+            reference_number: self.reference_number.clone(),
+            monotonic_time_milliseconds: self.monotonic_time_milliseconds.clone(),
+            destination: self.destination.clone(),
+            heap: cloned_heap,
+            message: cloned_heap_message,
+            position: self.position.clone(),
+        }
+    }
+}
+
+impl Eq for Timer {}
+
+impl PartialEq<Timer> for Timer {
+    fn eq(&self, other: &Timer) -> bool {
+        self.reference_number == other.reference_number
+    }
+}
+
+impl Ord for Timer {
+    fn cmp(&self, other: &Timer) -> Ordering {
+        // Timers are ordered in reverse order as `BinaryHeap` is a max heap, but we want sooner
+        // timers at the top
+        other
+            .monotonic_time_milliseconds
+            .cmp(&self.monotonic_time_milliseconds)
+            .then_with(|| other.reference_number.cmp(&self.reference_number))
+    }
+}
+
+impl PartialOrd for Timer {
+    fn partial_cmp(&self, other: &Timer) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[cfg_attr(test, derive(Debug))]
+struct Hierarchy {
+    at_once: BinaryHeap<Rc<Timer>>,
+    soon: Wheel,
+    later: Wheel,
+    long_term: BinaryHeap<Rc<Timer>>,
+    timer_by_reference_number: HashMap<reference::local::Number, rc::Weak<Timer>>,
+}
+
+impl Hierarchy {
+    const SOON_MILLISECONDS_PER_SLOT: Milliseconds = 1;
+    const SOON_TOTAL_MILLISECONDS: Milliseconds =
+        Self::SOON_MILLISECONDS_PER_SLOT * (Wheel::LENGTH as Milliseconds);
+    const LATER_MILLISECONDS_PER_SLOT: Milliseconds = Self::SOON_TOTAL_MILLISECONDS / 2;
+    const LATER_TOTAL_MILLISECONDS: Milliseconds =
+        Self::LATER_MILLISECONDS_PER_SLOT * (Wheel::LENGTH as Milliseconds);
+
+    fn position(&self, monotonic_time_milliseconds: Milliseconds) -> Position {
+        if monotonic_time_milliseconds < self.soon.slot_monotonic_time_milliseconds {
+            Position::AtOnce
+        } else if monotonic_time_milliseconds < self.later.slot_monotonic_time_milliseconds {
+            Position::Soon {
+                slot_index: self.soon.slot_index(monotonic_time_milliseconds),
+            }
+        } else if monotonic_time_milliseconds
+            < (self.later.slot_monotonic_time_milliseconds + Self::LATER_TOTAL_MILLISECONDS)
+        {
+            Position::Later {
+                slot_index: self.later.slot_index(monotonic_time_milliseconds),
+            }
+        } else {
+            Position::LongTerm
+        }
+    }
+
+    fn start(
+        &mut self,
+        monotonic_time_milliseconds: Milliseconds,
+        destination: Destination,
+        process_message: Term,
+        process: &Process,
+    ) -> &'static reference::local::Reference {
+        let reference = process.local_reference();
+        let reference_number = reference.number();
+        let heap: heap::Heap = Default::default();
+        let heap_message = process_message.clone_into_heap(&heap);
+        let position = self.position(monotonic_time_milliseconds);
+
+        let timer = Timer {
+            reference_number,
+            monotonic_time_milliseconds,
+            destination,
+            heap,
+            message: heap_message,
+            position,
+        };
+        let timer_rc = Rc::new(timer);
+        let timeoutable = Rc::clone(&timer_rc);
+        let cancellable = Rc::downgrade(&timer_rc);
+
+        match position {
+            Position::AtOnce => self.at_once.push(timeoutable),
+            Position::Soon { slot_index } => self.soon[slot_index].push(timeoutable),
+            Position::Later { slot_index } => self.later[slot_index].push(timeoutable),
+            Position::LongTerm => self.long_term.push(timeoutable),
+        }
+
+        self.timer_by_reference_number
+            .insert(reference_number, cancellable);
+
+        reference
+    }
+
+    fn timeout(&mut self) {
+        self.timeout_at_once();
+
+        let monotonic_time_milliseconds = monotonic::time_in_milliseconds();
+        let milliseconds = monotonic_time_milliseconds - self.soon.slot_monotonic_time_milliseconds;
+
+        for _ in 0..milliseconds {
+            self.timeout_soon_slot();
+
+            assert!(self.soon.peek().is_none());
+            self.soon.next_slot();
+
+            let soon_max_monotonic_time_milliseconds = self.soon.max_monotonic_time_milliseconds();
+
+            if self.later.slot_monotonic_time_milliseconds <= soon_max_monotonic_time_milliseconds {
+                self.transfer_later_to_soon(soon_max_monotonic_time_milliseconds);
+
+                let later_next_slot_monotonic_time_milliseconds =
+                    self.later.next_slot_monotonic_time_milliseconds();
+
+                if later_next_slot_monotonic_time_milliseconds
+                    <= soon_max_monotonic_time_milliseconds
+                {
+                    assert!(self.later.peek().is_none());
+                    self.later.next_slot();
+
+                    let later_max_monotonic_time_milliseconds =
+                        self.later.max_monotonic_time_milliseconds();
+
+                    self.transfer_long_term_to_later(later_max_monotonic_time_milliseconds);
+                }
+            }
+        }
+    }
+
+    fn timeout_at_once(&mut self) {
+        while let Some(timer_rc) = self.at_once.pop() {
+            self.timer_by_reference_number
+                .remove(&timer_rc.reference_number);
+
+            Rc::try_unwrap(timer_rc).unwrap().timeout()
+        }
+    }
+
+    fn timeout_soon_slot(&mut self) {
+        while let Some(timer_rc) = self.soon.pop() {
+            self.timer_by_reference_number
+                .remove(&timer_rc.reference_number);
+
+            Rc::try_unwrap(timer_rc).unwrap().timeout()
+        }
+    }
+
+    fn transfer(&mut self, mut transferable_timer_rc: Rc<Timer>, wheel_name: WheelName) {
+        let wheel = match wheel_name {
+            WheelName::Soon => &mut self.soon,
+            WheelName::Later => &mut self.later,
+        };
+
+        let slot_index = wheel.slot_index(transferable_timer_rc.monotonic_time_milliseconds);
+
+        let position = match wheel_name {
+            WheelName::Soon => Position::Soon { slot_index },
+            WheelName::Later => Position::Later { slot_index },
+        };
+
+        // Remove weak reference to allow `get_mut`.
+        let reference_number = transferable_timer_rc.reference_number;
+        self.timer_by_reference_number.remove(&reference_number);
+
+        Rc::get_mut(&mut transferable_timer_rc).unwrap().position = position;
+
+        let timeoutable = Rc::clone(&transferable_timer_rc);
+        let cancellable = Rc::downgrade(&transferable_timer_rc);
+
+        wheel[slot_index].push(timeoutable);
+        self.timer_by_reference_number
+            .insert(reference_number, cancellable);
+    }
+
+    fn transfer_later_to_soon(&mut self, soon_max_monotonic_time_milliseconds: Milliseconds) {
+        while let Some(check_timer_rc) = self.later.peek() {
+            if check_timer_rc.monotonic_time_milliseconds <= soon_max_monotonic_time_milliseconds {
+                let transferable_timer_rc = self.later.pop().unwrap();
+
+                self.transfer(transferable_timer_rc, WheelName::Soon);
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn transfer_long_term_to_later(&mut self, later_max_monotonic_time_milliseconds: Milliseconds) {
+        while let Some(check_timer_rc) = self.long_term.peek() {
+            if check_timer_rc.monotonic_time_milliseconds <= later_max_monotonic_time_milliseconds {
+                let transferable_timer_rc = self.long_term.pop().unwrap();
+
+                self.transfer(transferable_timer_rc, WheelName::Later);
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+impl Default for Hierarchy {
+    fn default() -> Hierarchy {
+        let monotonic_time_milliseconds = monotonic::time_in_milliseconds();
+
+        let soon_slot_index = ((monotonic_time_milliseconds % Self::SOON_TOTAL_MILLISECONDS)
+            / Self::SOON_MILLISECONDS_PER_SLOT) as u16;
+        // round down to nearest multiple
+        let soon_slot_monotonic_time_milliseconds = (monotonic_time_milliseconds
+            / Self::SOON_TOTAL_MILLISECONDS)
+            * Self::SOON_TOTAL_MILLISECONDS;
+        let soon = Wheel::new(
+            Self::SOON_MILLISECONDS_PER_SLOT,
+            soon_slot_index,
+            soon_slot_monotonic_time_milliseconds,
+        );
+
+        // > The later wheel contain timers that are further away from 'pos'
+        // > than the width of the soon timer wheel.
+        // -- https://github.com/erlang/otp/blob/759ec896d7f254db2996cbb503c1ef883e6714b0/erts/emulator/beam/time.c#L68-L69
+        let later_monotonic_time_milliseconds =
+            soon_slot_monotonic_time_milliseconds + Self::SOON_TOTAL_MILLISECONDS;
+        let later_slot_index = ((later_monotonic_time_milliseconds
+            % Self::LATER_TOTAL_MILLISECONDS)
+            / Self::LATER_MILLISECONDS_PER_SLOT) as u16;
+        // round down to nearest multiple
+        let later_slot_monotonic_time_milliseconds = (later_monotonic_time_milliseconds
+            / Self::LATER_MILLISECONDS_PER_SLOT)
+            * Self::LATER_MILLISECONDS_PER_SLOT;
+        let later = Wheel::new(
+            Self::LATER_MILLISECONDS_PER_SLOT,
+            later_slot_index,
+            later_slot_monotonic_time_milliseconds,
+        );
+
+        Hierarchy {
+            at_once: Default::default(),
+            soon,
+            later,
+            long_term: Default::default(),
+            timer_by_reference_number: Default::default(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Position {
+    AtOnce,
+    Soon { slot_index: u16 },
+    Later { slot_index: u16 },
+    LongTerm,
+}
+
+#[cfg_attr(test, derive(Debug))]
+struct Wheel {
+    milliseconds_per_slot: Milliseconds,
+    total_milliseconds: Milliseconds,
+    slots: Vec<BinaryHeap<Rc<Timer>>>,
+    slot_index: u16,
+    slot_monotonic_time_milliseconds: Milliseconds,
+}
+
+impl Wheel {
+    // same as values used in BEAM
+    #[cfg(not(test))]
+    const LENGTH: u16 = 1 << 14;
+    // super short so that later and long term tests don't take forever
+    #[cfg(test)]
+    const LENGTH: u16 = 1 << 2;
+
+    fn new(
+        milliseconds_per_slot: Milliseconds,
+        slot_index: u16,
+        slot_monotonic_time_milliseconds: Milliseconds,
+    ) -> Wheel {
+        Wheel {
+            milliseconds_per_slot,
+            total_milliseconds: milliseconds_per_slot * (Self::LENGTH as Milliseconds),
+            slots: vec![Default::default(); Self::LENGTH as usize],
+            slot_index,
+            slot_monotonic_time_milliseconds,
+        }
+    }
+
+    fn max_monotonic_time_milliseconds(&self) -> Milliseconds {
+        self.slot_monotonic_time_milliseconds + self.total_milliseconds - 1
+    }
+
+    fn next_slot(&mut self) {
+        self.slot_index = (self.slot_index + 1) % Self::LENGTH;
+        self.slot_monotonic_time_milliseconds += self.milliseconds_per_slot;
+    }
+
+    fn next_slot_monotonic_time_milliseconds(&self) -> Milliseconds {
+        self.slot_monotonic_time_milliseconds + self.milliseconds_per_slot
+    }
+
+    fn peek(&self) -> Option<&Rc<Timer>> {
+        self.slots[self.slot_index as usize].peek()
+    }
+
+    fn pop(&mut self) -> Option<Rc<Timer>> {
+        self.slots[self.slot_index as usize].pop()
+    }
+
+    fn slot_index(&self, monotonic_time_milliseconds: Milliseconds) -> u16 {
+        let milliseconds = monotonic_time_milliseconds - self.slot_monotonic_time_milliseconds;
+        let slots = (milliseconds / self.milliseconds_per_slot) as u16;
+
+        assert!(slots < Wheel::LENGTH, "monotonic_time_milliseconds ({:?}) is {:?} milliseconds ({:?} slots) away from slot_monotonic_time_milliseconds {:?}, but wheel only has {:?} slots ", monotonic_time_milliseconds, milliseconds, slots, self.slot_monotonic_time_milliseconds, Wheel::LENGTH);
+
+        (self.slot_index + slots) % Wheel::LENGTH
+    }
+}
+
+impl Index<u16> for Wheel {
+    type Output = BinaryHeap<Rc<Timer>>;
+
+    fn index(&self, slot_index: u16) -> &BinaryHeap<Rc<Timer>> {
+        self.slots.index(slot_index as usize)
+    }
+}
+
+impl IndexMut<u16> for Wheel {
+    fn index_mut(&mut self, slot_index: u16) -> &mut BinaryHeap<Rc<Timer>> {
+        self.slots.index_mut(slot_index as usize)
+    }
+}
+
+enum WheelName {
+    Soon,
+    Later,
+}
+
+thread_local! {
+   static HIERARCHY: RefCell<Hierarchy> = RefCell::new(Default::default());
+}
+
+#[cfg(test)]
+pub fn at_once_milliseconds() -> Milliseconds {
+    0
+}
+
+#[cfg(test)]
+pub fn soon_milliseconds() -> Milliseconds {
+    let milliseconds: Milliseconds = 1;
+
+    assert!(milliseconds < Hierarchy::SOON_TOTAL_MILLISECONDS);
+
+    milliseconds
+}
+
+#[cfg(test)]
+pub fn later_milliseconds() -> Milliseconds {
+    let milliseconds = Hierarchy::SOON_TOTAL_MILLISECONDS + 1;
+
+    assert!(Hierarchy::SOON_TOTAL_MILLISECONDS < milliseconds);
+    assert!(milliseconds < Hierarchy::LATER_TOTAL_MILLISECONDS);
+
+    milliseconds
+}
+
+#[cfg(test)]
+pub fn long_term_milliseconds() -> Milliseconds {
+    let milliseconds = Hierarchy::SOON_TOTAL_MILLISECONDS + Hierarchy::LATER_TOTAL_MILLISECONDS + 1;
+
+    assert!(Hierarchy::SOON_TOTAL_MILLISECONDS < milliseconds);
+    assert!(
+        (Hierarchy::SOON_TOTAL_MILLISECONDS + Hierarchy::LATER_TOTAL_MILLISECONDS) < milliseconds
+    );
+
+    milliseconds
+}


### PR DESCRIPTION
# Changelog
## Enhancements
*  Start and timeout timers.  Timers are timed out by calling `timer::timeout`.  There is hierarchy of timers per scheduler.  As schedulers don't exist right now, the timer hierarchies are thread local.

   The `timer::Hierarchy` is based on the timer hiearchy used in BEAM and described in
[erlang/otp/erts/emulator/beam/time.c](https://github.com/erlang/otp/blob/759ec896d7f254db2996cbb503c1ef883e6714b0/erts/emulator/beam/time.c#L21-L171).

   * `at_once`
   * `soon`
   * `later`
   * `long_term`

   Although `erlang::start_timer_3` uses relative milliseconds, the timers and `Hierarchy` use absolute monotonic time in milliseconds.  As such, it is possible to start a timer that is before the current monotonic timer in millisecond, which are put in the `at_once` min-heap to timeout the next time `timer::timeout` is called.

   Timers set to timeout in the next 2¹⁴ milliseconds (~16 seconds) are stored in `soon` with one slot per millisecond.

   Timers set to timeout between 2¹⁴ milliseconds and 2²⁸ milliseconds (~74 hours) are stored in `later` with one slot per 2¹³ (~8 seconds, half the total milliseconds in `soon`).  Whenever `soon`'s `slot_index` advances, it is checked if any timers in `later`'s `slot_index` should be transfered to
`soon`.  Timers are stored in a `min-heap` so as soon as the top of the slot does not need to be transferred, no more timers need to checked in the slot.  If the `soon`'s domain ever extends beyond the last millisecond in the current `later` `slot_index`, `later`'s slot advances.

   Timers that are beyond `later` are store in a single min-heap, `long_term`.  Whenever `later`'s `slot_index` advances, it is checked if any timers in `long_term` should be transferred to `later`.  Because of the min-heap, as soon as the top of `later` does not need to be transferred, no more timers need to be checked.

   For testing, `soon` and `later` are restricted to 4 slots, the lowest power of two to have a start (`0`), middle (`1`, `2`), and end ('3`) index.