### PR TITLE
:erlang.cancel_timer/1

### DIFF
--- a/lumen_runtime/src/binary/sub.rs
+++ b/lumen_runtime/src/binary/sub.rs
@@ -503,7 +503,7 @@ impl PartToList<usize, isize> for Binary {
 mod tests {
     use super::*;
 
-    use crate::process;
+    use crate::scheduler::with_process;
 
     mod bit_count_iter {
         use super::*;
@@ -513,118 +513,126 @@ mod tests {
 
             #[test]
             fn with_0_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111], &process);
-                let subbinary = Binary::new(binary, 0, 0, 1, 0);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111], process);
+                    let subbinary = Binary::new(binary, 0, 0, 1, 0);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_1_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1000_0000], &process);
-                let subbinary = Binary::new(binary, 0, 0, 1, 1);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1000_0000], process);
+                    let subbinary = Binary::new(binary, 0, 0, 1, 1);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_2_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1100_0000], &process);
-                let subbinary = Binary::new(binary, 0, 0, 1, 2);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1100_0000], process);
+                    let subbinary = Binary::new(binary, 0, 0, 1, 2);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_3_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1110_0000], &process);
-                let subbinary = Binary::new(binary, 0, 0, 1, 3);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1110_0000], process);
+                    let subbinary = Binary::new(binary, 0, 0, 1, 3);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_4_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_0000], &process);
-                let subbinary = Binary::new(binary, 0, 0, 1, 4);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_0000], process);
+                    let subbinary = Binary::new(binary, 0, 0, 1, 4);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_5_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1000], &process);
-                let subbinary = Binary::new(binary, 0, 0, 1, 5);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1000], process);
+                    let subbinary = Binary::new(binary, 0, 0, 1, 5);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_6_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1100], &process);
-                let subbinary = Binary::new(binary, 0, 0, 1, 6);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1100], process);
+                    let subbinary = Binary::new(binary, 0, 0, 1, 6);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_7_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1110], &process);
-                let subbinary = Binary::new(binary, 0, 0, 1, 7);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1110], process);
+                    let subbinary = Binary::new(binary, 0, 0, 1, 7);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
         }
 
@@ -633,118 +641,126 @@ mod tests {
 
             #[test]
             fn with_0_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1000_0000], &process);
-                let subbinary = Binary::new(binary, 0, 1, 1, 0);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1000_0000], process);
+                    let subbinary = Binary::new(binary, 0, 1, 1, 0);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_1_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1100_0000], &process);
-                let subbinary = Binary::new(binary, 0, 1, 1, 1);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1100_0000], process);
+                    let subbinary = Binary::new(binary, 0, 1, 1, 1);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_2_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1110_0000], &process);
-                let subbinary = Binary::new(binary, 0, 1, 1, 2);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1110_0000], process);
+                    let subbinary = Binary::new(binary, 0, 1, 1, 2);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_3_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_0000], &process);
-                let subbinary = Binary::new(binary, 0, 1, 1, 3);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_0000], process);
+                    let subbinary = Binary::new(binary, 0, 1, 1, 3);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_4_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1000], &process);
-                let subbinary = Binary::new(binary, 0, 1, 1, 4);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1000], process);
+                    let subbinary = Binary::new(binary, 0, 1, 1, 4);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_5_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1100], &process);
-                let subbinary = Binary::new(binary, 0, 1, 1, 5);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1100], process);
+                    let subbinary = Binary::new(binary, 0, 1, 1, 5);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_6_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1110], &process);
-                let subbinary = Binary::new(binary, 0, 1, 1, 6);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1110], process);
+                    let subbinary = Binary::new(binary, 0, 1, 1, 6);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
 
             #[test]
             fn with_7_bit_count() {
-                let process = process::local::new();
-                let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1111], &process);
-                let subbinary = Binary::new(binary, 0, 1, 1, 7);
+                with_process(|process| {
+                    let binary = Term::slice_to_binary(&[0b1111_1111, 0b1111_1111], process);
+                    let subbinary = Binary::new(binary, 0, 1, 1, 7);
 
-                let mut bit_count_iter = subbinary.bit_count_iter();
+                    let mut bit_count_iter = subbinary.bit_count_iter();
 
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), Some(1));
-                assert_eq!(bit_count_iter.next(), None);
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), Some(1));
+                    assert_eq!(bit_count_iter.next(), None);
+                });
             }
         }
     }
@@ -754,34 +770,35 @@ mod tests {
 
         #[test]
         fn is_double_ended() {
-            let process = process::local::new();
-            // <<1::1, 0, 1, 2>>
-            let binary = Term::slice_to_binary(&[128, 0, 129, 0b0000_0000], &process);
-            let subbinary = Binary::new(binary, 0, 1, 3, 0);
+            with_process(|process| {
+                // <<1::1, 0, 1, 2>>
+                let binary = Term::slice_to_binary(&[128, 0, 129, 0b0000_0000], process);
+                let subbinary = Binary::new(binary, 0, 1, 3, 0);
 
-            let mut iter = subbinary.byte_iter();
+                let mut iter = subbinary.byte_iter();
 
-            assert_eq!(iter.next(), Some(0));
-            assert_eq!(iter.next(), Some(1));
-            assert_eq!(iter.next(), Some(2));
-            assert_eq!(iter.next(), None);
-            assert_eq!(iter.next(), None);
+                assert_eq!(iter.next(), Some(0));
+                assert_eq!(iter.next(), Some(1));
+                assert_eq!(iter.next(), Some(2));
+                assert_eq!(iter.next(), None);
+                assert_eq!(iter.next(), None);
 
-            let mut rev_iter = subbinary.byte_iter();
+                let mut rev_iter = subbinary.byte_iter();
 
-            assert_eq!(rev_iter.next_back(), Some(2));
-            assert_eq!(rev_iter.next_back(), Some(1));
-            assert_eq!(rev_iter.next_back(), Some(0));
-            assert_eq!(rev_iter.next_back(), None);
-            assert_eq!(rev_iter.next_back(), None);
+                assert_eq!(rev_iter.next_back(), Some(2));
+                assert_eq!(rev_iter.next_back(), Some(1));
+                assert_eq!(rev_iter.next_back(), Some(0));
+                assert_eq!(rev_iter.next_back(), None);
+                assert_eq!(rev_iter.next_back(), None);
 
-            let mut double_ended_iter = subbinary.byte_iter();
+                let mut double_ended_iter = subbinary.byte_iter();
 
-            assert_eq!(double_ended_iter.next(), Some(0));
-            assert_eq!(double_ended_iter.next_back(), Some(2));
-            assert_eq!(double_ended_iter.next(), Some(1));
-            assert_eq!(double_ended_iter.next_back(), None);
-            assert_eq!(double_ended_iter.next(), None);
+                assert_eq!(double_ended_iter.next(), Some(0));
+                assert_eq!(double_ended_iter.next_back(), Some(2));
+                assert_eq!(double_ended_iter.next(), Some(1));
+                assert_eq!(double_ended_iter.next_back(), None);
+                assert_eq!(double_ended_iter.next(), None);
+            });
         }
     }
 }

--- a/lumen_runtime/src/heap.rs
+++ b/lumen_runtime/src/heap.rs
@@ -12,6 +12,7 @@ use crate::list::Cons;
 use crate::map::Map;
 use crate::process::identifier;
 use crate::reference;
+use crate::scheduler;
 use crate::term::Term;
 use crate::tuple::Tuple;
 
@@ -67,20 +68,14 @@ impl Heap {
         unsafe { &*pointer }
     }
 
-    pub fn local_reference(&self) -> &'static reference::local::Reference {
+    pub fn local_reference(
+        &self,
+        scheduler_id: &scheduler::ID,
+        number: reference::local::Number,
+    ) -> &'static reference::local::Reference {
         let pointer = self
             .local_reference_arena
-            .alloc(reference::local::Reference::next())
-            as *const reference::local::Reference;
-
-        unsafe { &*pointer }
-    }
-
-    #[cfg(test)]
-    pub fn number_to_local_reference(&self, number: u64) -> &'static reference::local::Reference {
-        let pointer = self
-            .local_reference_arena
-            .alloc(reference::local::Reference::new(number))
+            .alloc(reference::local::Reference::new(scheduler_id, number))
             as *const reference::local::Reference;
 
         unsafe { &*pointer }
@@ -146,15 +141,6 @@ impl Heap {
 
     pub fn slice_to_tuple(&self, slice: &[Term]) -> &'static Tuple {
         Tuple::from_slice(slice, &self)
-    }
-
-    pub fn u64_to_local_reference(&self, number: u64) -> &'static reference::local::Reference {
-        let pointer = self
-            .local_reference_arena
-            .alloc(reference::local::Reference::new(number))
-            as *const reference::local::Reference;
-
-        unsafe { &*pointer }
     }
 }
 

--- a/lumen_runtime/src/lib.rs
+++ b/lumen_runtime/src/lib.rs
@@ -48,6 +48,7 @@ mod node;
 pub mod otp;
 mod reference;
 mod registry;
+mod scheduler;
 mod send;
 mod stacktrace;
 mod system;

--- a/lumen_runtime/src/list.rs
+++ b/lumen_runtime/src/list.rs
@@ -332,35 +332,36 @@ where
 mod tests {
     use super::*;
 
-    use crate::process;
-
     mod eq {
         use super::*;
 
         use crate::process::IntoProcess;
+        use crate::scheduler::with_process;
 
         #[test]
         fn with_proper() {
-            let process = process::local::new();
-            let cons = Cons::new(0.into_process(&process), Term::EMPTY_LIST);
-            let equal = Cons::new(0.into_process(&process), Term::EMPTY_LIST);
-            let unequal = Cons::new(1.into_process(&process), Term::EMPTY_LIST);
+            with_process(|process| {
+                let cons = Cons::new(0.into_process(process), Term::EMPTY_LIST);
+                let equal = Cons::new(0.into_process(process), Term::EMPTY_LIST);
+                let unequal = Cons::new(1.into_process(process), Term::EMPTY_LIST);
 
-            assert_eq!(cons, cons);
-            assert_eq!(cons, equal);
-            assert_ne!(cons, unequal);
+                assert_eq!(cons, cons);
+                assert_eq!(cons, equal);
+                assert_ne!(cons, unequal);
+            });
         }
 
         #[test]
         fn with_improper() {
-            let process = process::local::new();
-            let cons = Cons::new(0.into_process(&process), 1.into_process(&process));
-            let equal = Cons::new(0.into_process(&process), 1.into_process(&process));
-            let unequal = Cons::new(1.into_process(&process), 0.into_process(&process));
+            with_process(|process| {
+                let cons = Cons::new(0.into_process(process), 1.into_process(process));
+                let equal = Cons::new(0.into_process(process), 1.into_process(process));
+                let unequal = Cons::new(1.into_process(process), 0.into_process(process));
 
-            assert_eq!(cons, cons);
-            assert_eq!(cons, equal);
-            assert_ne!(cons, unequal);
+                assert_eq!(cons, cons);
+                assert_eq!(cons, equal);
+                assert_ne!(cons, unequal);
+            });
         }
     }
 }

--- a/lumen_runtime/src/mailbox.rs
+++ b/lumen_runtime/src/mailbox.rs
@@ -1,7 +1,15 @@
 #[cfg(test)]
+use std::fmt::{self, Debug};
+#[cfg(test)]
 use std::slice::Iter;
+#[cfg(test)]
+use std::sync::MutexGuard;
 
+#[cfg(test)]
+use crate::heap::{CloneIntoHeap, Heap};
 use crate::message::Message;
+#[cfg(test)]
+use crate::term::Term;
 
 pub struct Mailbox {
     messages: Vec<Message>,
@@ -15,6 +23,32 @@ impl Mailbox {
     #[cfg(test)]
     pub fn iter(&self) -> Iter<Message> {
         self.messages.iter()
+    }
+
+    #[cfg(test)]
+    pub fn receive(&mut self, unlocked_heap: MutexGuard<Heap>) -> Option<Term> {
+        if self.messages.is_empty() {
+            None
+        } else {
+            let singleton: Vec<Message> = self.messages.drain(0..1).collect();
+
+            let received = match singleton[0] {
+                Message::Heap {
+                    message: message_heap_message,
+                    ..
+                } => message_heap_message.clone_into_heap(&unlocked_heap),
+                Message::Process(process_message) => process_message,
+            };
+
+            Some(received)
+        }
+    }
+}
+
+#[cfg(test)]
+impl Debug for Mailbox {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.messages)
     }
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/abs_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/abs_1.rs
@@ -11,7 +11,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(&process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/add_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/add_2.rs
@@ -11,7 +11,7 @@ fn with_atom_augend_errors_badarith() {
 
 #[test]
 fn with_local_reference_augend_errors_badarith() {
-    with_augend_errors_badarith(|process| Term::local_reference(&process));
+    with_augend_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/add_2/with_big_integer_augend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/add_2/with_big_integer_augend.rs
@@ -7,7 +7,7 @@ fn with_atom_addend_errors_badarith() {
 
 #[test]
 fn with_local_reference_addend_errors_badarith() {
-    with_addend_errors_badarith(|process| Term::local_reference(&process));
+    with_addend_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/add_2/with_float_augend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/add_2/with_float_augend.rs
@@ -7,7 +7,7 @@ fn with_atom_addend_errors_badarith() {
 
 #[test]
 fn with_local_reference_addend_errors_badarith() {
-    with_addend_errors_badarith(|process| Term::local_reference(&process));
+    with_addend_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/add_2/with_small_integer_augend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/add_2/with_small_integer_augend.rs
@@ -7,7 +7,7 @@ fn with_atom_addend_errors_badarith() {
 
 #[test]
 fn with_local_reference_addend_errors_badarith() {
-    with_addend_errors_badarith(|process| Term::local_reference(&process));
+    with_addend_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/and_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/and_2.rs
@@ -10,7 +10,7 @@ fn with_atom_left_errors_badarg() {
 
 #[test]
 fn with_local_reference_left_errors_badarg() {
-    with_left_errors_badarg(|process| Term::local_reference(&process));
+    with_left_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/and_2/with_false_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/and_2/with_false_left.rs
@@ -21,7 +21,7 @@ fn with_true_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_errors_badarg() {
-    with_right_errors_badarg(|process| Term::local_reference(&process));
+    with_right_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/and_2/with_true_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/and_2/with_true_left.rs
@@ -21,7 +21,7 @@ fn with_true_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_errors_badarg() {
-    with_right_errors_badarg(|process| Term::local_reference(&process));
+    with_right_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/andalso_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/andalso_2.rs
@@ -10,7 +10,7 @@ fn with_atom_left_errors_badarg() {
 
 #[test]
 fn with_local_reference_left_errors_badarg() {
-    with_left_errors_badarg(|process| Term::local_reference(&process));
+    with_left_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/andalso_2/with_false_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/andalso_2/with_false_left.rs
@@ -17,7 +17,7 @@ fn with_true_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    with_right_returns_false(|process| Term::local_reference(&process));
+    with_right_returns_false(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/andalso_2/with_true_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/andalso_2/with_true_left.rs
@@ -17,7 +17,7 @@ fn with_true_right_returns_right() {
 
 #[test]
 fn with_local_reference_right_returns_right() {
-    with_right_returns_right(|process| Term::local_reference(&process));
+    with_right_returns_right(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/append_element_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/append_element_2.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_atom_left.rs
@@ -17,7 +17,7 @@ fn with_different_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_big_integer_left.rs
@@ -7,7 +7,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_empty_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_empty_list_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_external_pid_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_float_left.rs
@@ -7,7 +7,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_heap_binary_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_list_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_local_pid_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_local_reference_left.rs
@@ -12,7 +12,7 @@ fn with_same_local_reference_right_returns_true() {
 
 #[test]
 fn with_different_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]
@@ -83,5 +83,9 @@ fn are_equal_after_conversion<R>(right: R, expected: bool)
 where
     R: FnOnce(Term, &Process) -> Term,
 {
-    super::are_equal_after_conversion(|process| Term::local_reference(&process), right, expected);
+    super::are_equal_after_conversion(
+        |process| Term::next_local_reference(process),
+        right,
+        expected,
+    );
 }

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_map_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_small_integer_left.rs
@@ -7,7 +7,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_subbinary_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_tuple_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_equal_after_conversion(|_, process| Term::local_reference(&process), false);
+    are_equal_after_conversion(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_atom_left.rs
@@ -17,7 +17,7 @@ fn with_different_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_big_integer_left.rs
@@ -7,7 +7,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_empty_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_empty_list_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_external_pid_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_float_left.rs
@@ -7,7 +7,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_heap_binary_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_list_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_local_pid_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_local_reference_left.rs
@@ -12,7 +12,7 @@ fn with_same_local_reference_right_returns_true() {
 
 #[test]
 fn with_different_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]
@@ -83,5 +83,9 @@ fn are_exactly_equal<R>(right: R, expected: bool)
 where
     R: FnOnce(Term, &Process) -> Term,
 {
-    super::are_exactly_equal(|process| Term::local_reference(&process), right, expected);
+    super::are_exactly_equal(
+        |process| Term::next_local_reference(process),
+        right,
+        expected,
+    );
 }

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_map_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_small_integer_left.rs
@@ -7,7 +7,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_subbinary_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_tuple_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    are_exactly_equal(|_, process| Term::local_reference(&process), false);
+    are_exactly_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_atom_left.rs
@@ -17,7 +17,7 @@ fn with_different_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_big_integer_left.rs
@@ -7,7 +7,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_empty_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_empty_list_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_external_pid_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_float_left.rs
@@ -7,7 +7,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_heap_binary_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_list_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_local_pid_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_local_reference_left.rs
@@ -12,7 +12,7 @@ fn with_same_local_reference_right_returns_false() {
 
 #[test]
 fn with_different_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]
@@ -83,5 +83,9 @@ fn are_exactly_not_equal<R>(right: R, expected: bool)
 where
     R: FnOnce(Term, &Process) -> Term,
 {
-    super::are_exactly_not_equal(|process| Term::local_reference(&process), right, expected);
+    super::are_exactly_not_equal(
+        |process| Term::next_local_reference(process),
+        right,
+        expected,
+    );
 }

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_map_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_small_integer_left.rs
@@ -7,7 +7,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_subbinary_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_tuple_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_exactly_not_equal(|_, process| Term::local_reference(&process), true);
+    are_exactly_not_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_atom_left.rs
@@ -17,7 +17,7 @@ fn with_different_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_big_integer_left.rs
@@ -7,7 +7,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_empty_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_empty_list_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_external_pid_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_float_left.rs
@@ -7,7 +7,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_heap_binary_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_list_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_local_pid_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_local_reference_left.rs
@@ -12,7 +12,7 @@ fn with_same_local_reference_right_returns_false() {
 
 #[test]
 fn with_different_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]
@@ -84,7 +84,7 @@ where
     R: FnOnce(Term, &Process) -> Term,
 {
     super::are_not_equal_after_conversion(
-        |process| Term::local_reference(&process),
+        |process| Term::next_local_reference(process),
         right,
         expected,
     );

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_map_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_small_integer_left.rs
@@ -7,7 +7,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_subbinary_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_tuple_left.rs
@@ -7,7 +7,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    are_not_equal_after_conversion(|_, process| Term::local_reference(&process), true);
+    are_not_equal_after_conversion(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/atom_to_binary_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/atom_to_binary_2.rs
@@ -59,7 +59,7 @@ fn with_atom_with_encoding_atom_returns_name_in_binary() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/atom_to_list_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/atom_to_list_1.rs
@@ -23,7 +23,7 @@ fn with_atom_returns_chars_in_list() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/band_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/band_2.rs
@@ -10,7 +10,7 @@ fn with_atom_left_errors_badarith() {
 
 #[test]
 fn with_local_reference_left_errors_badarith() {
-    with_left_errors_badarith(|process| Term::local_reference(&process));
+    with_left_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/band_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/band_2/with_big_integer_left.rs
@@ -11,7 +11,7 @@ fn with_atom_right_errors_badarith() {
 
 #[test]
 fn with_local_reference_right_errors_badarith() {
-    with_right_errors_badarith(|process| Term::local_reference(&process));
+    with_right_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]
@@ -66,8 +66,6 @@ fn with_big_integer_right_returns_big_integer() {
         assert!(result.is_ok());
 
         let output = result.unwrap();
-
-        println!("output = {:?}", output);
 
         assert_eq!(output.tag(), Boxed);
 

--- a/lumen_runtime/src/otp/erlang/tests/band_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/band_2/with_small_integer_left.rs
@@ -11,7 +11,7 @@ fn with_atom_right_errors_badarith() {
 
 #[test]
 fn with_local_reference_right_errors_badarith() {
-    with_right_errors_badarith(|process| Term::local_reference(&process));
+    with_right_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/binary_part_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_part_2.rs
@@ -13,7 +13,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_binary_errors_badarg(|process| Term::local_reference(&process));
+    with_binary_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/binary_part_2/with_heap_binary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_part_2/with_heap_binary.rs
@@ -9,7 +9,7 @@ fn with_atom_start_length_errors_badarg() {
 
 #[test]
 fn with_local_reference_start_length_errors_badarg() {
-    with_start_length_errors_badarg(|process| Term::local_reference(&process));
+    with_start_length_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/binary_part_2/with_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_part_2/with_subbinary.rs
@@ -9,7 +9,7 @@ fn with_atom_start_length_errors_badarg() {
 
 #[test]
 fn with_local_reference_start_length_errors_badarg() {
-    with_start_length_errors_badarg(|process| Term::local_reference(&process));
+    with_start_length_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/binary_part_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_part_3.rs
@@ -14,7 +14,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_atom_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_atom_2.rs
@@ -11,7 +11,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_existing_atom_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_existing_atom_2.rs
@@ -11,7 +11,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_float_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_float_1.rs
@@ -11,7 +11,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_integer_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_integer_1.rs
@@ -11,7 +11,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_integer_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_integer_2.rs
@@ -11,7 +11,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_list_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_list_1.rs
@@ -11,7 +11,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_list_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_list_3.rs
@@ -11,7 +11,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_term_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_term_1.rs
@@ -11,7 +11,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bit_size_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bit_size_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bitstring_to_list_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bitstring_to_list_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bnot_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bnot_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarith() {
 
 #[test]
 fn with_local_reference_errors_badarith() {
-    errors_badarith(|process| Term::local_reference(&process));
+    errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bor_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bor_2.rs
@@ -10,7 +10,7 @@ fn with_atom_left_errors_badarith() {
 
 #[test]
 fn with_local_reference_left_errors_badarith() {
-    with_left_errors_badarith(|process| Term::local_reference(&process));
+    with_left_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bor_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bor_2/with_big_integer_left.rs
@@ -11,7 +11,7 @@ fn with_atom_right_errors_badarith() {
 
 #[test]
 fn with_local_reference_right_errors_badarith() {
-    with_right_errors_badarith(|process| Term::local_reference(&process));
+    with_right_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]
@@ -75,8 +75,6 @@ fn with_big_integer_right_returns_big_integer() {
         assert!(result.is_ok());
 
         let output = result.unwrap();
-
-        println!("output = {:?}", output);
 
         assert_eq!(output.tag(), Boxed);
 

--- a/lumen_runtime/src/otp/erlang/tests/bor_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bor_2/with_small_integer_left.rs
@@ -11,7 +11,7 @@ fn with_atom_right_errors_badarith() {
 
 #[test]
 fn with_local_reference_right_errors_badarith() {
-    with_right_errors_badarith(|process| Term::local_reference(&process));
+    with_right_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bsl_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bsl_2.rs
@@ -10,7 +10,7 @@ fn with_atom_integer_errors_badarith() {
 
 #[test]
 fn with_local_reference_integer_errors_badarith() {
-    with_integer_errors_badarith(|process| Term::local_reference(&process));
+    with_integer_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bsl_2/with_big_integer_integer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bsl_2/with_big_integer_integer.rs
@@ -9,7 +9,7 @@ fn with_atom_shift_errors_badarith() {
 
 #[test]
 fn with_local_reference_shift_errors_badarith() {
-    with_shift_errors_badarith(|process| Term::local_reference(&process));
+    with_shift_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bsl_2/with_small_integer_integer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bsl_2/with_small_integer_integer.rs
@@ -9,7 +9,7 @@ fn with_atom_shift_errors_badarith() {
 
 #[test]
 fn with_local_reference_shift_errors_badarith() {
-    with_shift_errors_badarith(|process| Term::local_reference(&process));
+    with_shift_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bsr_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bsr_2.rs
@@ -10,7 +10,7 @@ fn with_atom_integer_errors_badarith() {
 
 #[test]
 fn with_local_reference_integer_errors_badarith() {
-    with_integer_errors_badarith(|process| Term::local_reference(&process));
+    with_integer_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bsr_2/with_big_integer_integer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bsr_2/with_big_integer_integer.rs
@@ -9,7 +9,7 @@ fn with_atom_shift_errors_badarith() {
 
 #[test]
 fn with_local_reference_shift_errors_badarith() {
-    with_shift_errors_badarith(|process| Term::local_reference(&process));
+    with_shift_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bsr_2/with_small_integer_integer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bsr_2/with_small_integer_integer.rs
@@ -9,7 +9,7 @@ fn with_atom_shift_errors_badarith() {
 
 #[test]
 fn with_local_reference_shift_errors_badarith() {
-    with_shift_errors_badarith(|process| Term::local_reference(&process));
+    with_shift_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bxor_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bxor_2.rs
@@ -10,7 +10,7 @@ fn with_atom_left_errors_badarith() {
 
 #[test]
 fn with_local_reference_left_errors_badarith() {
-    with_left_errors_badarith(|process| Term::local_reference(&process));
+    with_left_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/bxor_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bxor_2/with_big_integer_left.rs
@@ -11,7 +11,7 @@ fn with_atom_right_errors_badarith() {
 
 #[test]
 fn with_local_reference_right_errors_badarith() {
-    with_right_errors_badarith(|process| Term::local_reference(&process));
+    with_right_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]
@@ -78,8 +78,6 @@ fn with_big_integer_right_returns_big_integer() {
         assert!(result.is_ok());
 
         let output = result.unwrap();
-
-        println!("output = {:?}", output);
 
         assert_eq!(output.tag(), Boxed);
 

--- a/lumen_runtime/src/otp/erlang/tests/bxor_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bxor_2/with_small_integer_left.rs
@@ -11,7 +11,7 @@ fn with_atom_right_errors_badarith() {
 
 #[test]
 fn with_local_reference_right_errors_badarith() {
-    with_right_errors_badarith(|process| Term::local_reference(&process));
+    with_right_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/byte_size_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/byte_size_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_1.rs
@@ -1,0 +1,75 @@
+use super::*;
+
+mod with_local_reference;
+
+#[test]
+fn with_small_integer_timer_reference_errors_badarg() {
+    with_timer_reference_errors_badarg(|process| 1.into_process(process))
+}
+
+#[test]
+fn with_float_timer_reference_errors_badarg() {
+    with_timer_reference_errors_badarg(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_timer_reference_errors_badarg() {
+    with_timer_reference_errors_badarg(|process| (integer::small::MAX + 1).into_process(process));
+}
+
+#[test]
+fn with_atom_timer_reference_errors_badarg() {
+    with_timer_reference_errors_badarg(|_| Term::str_to_atom("atom", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_pid_timer_reference_errors_badarg() {
+    with_timer_reference_errors_badarg(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_timer_reference_errors_badarg() {
+    with_timer_reference_errors_badarg(|process| Term::external_pid(1, 0, 0, process).unwrap());
+}
+
+#[test]
+fn with_tuple_timer_reference_errors_badarg() {
+    with_timer_reference_errors_badarg(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_timer_reference_errors_badarg() {
+    with_timer_reference_errors_badarg(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_timer_reference_errors_badarg() {
+    with_timer_reference_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_timer_reference_errors_badarg() {
+    with_timer_reference_errors_badarg(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_timer_reference_errors_badarg() {
+    with_timer_reference_errors_badarg(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_timer_reference_errors_badarg() {
+    with_timer_reference_errors_badarg(|process| {
+        let original = Term::slice_to_binary(&[0, 1], process);
+        Term::subbinary(original, 1, 0, 1, 0, process)
+    });
+}
+
+fn with_timer_reference_errors_badarg<T>(timer_reference: T)
+where
+    T: FnOnce(&Process) -> Term,
+{
+    with_process(|process| {
+        assert_badarg!(erlang::cancel_timer_1(timer_reference(process), process));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_1/with_local_reference.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_1/with_local_reference.rs
@@ -1,0 +1,15 @@
+use super::*;
+
+mod with_timer;
+
+#[test]
+fn without_timer_returns_false() {
+    with_process(|process| {
+        let timer_reference = Term::next_local_reference(process);
+
+        assert_eq!(
+            erlang::cancel_timer_1(timer_reference, process),
+            Ok(false.into())
+        );
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_1/with_local_reference/with_timer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_1/with_local_reference/with_timer.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod in_different_thread;
+mod in_same_thread;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_1/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_1/with_local_reference/with_timer/in_different_thread.rs
@@ -1,0 +1,145 @@
+use super::*;
+
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn without_timeout_returns_milliseconds_remaining_and_does_not_send_timeout_message() {
+    with_timer(|milliseconds, barrier, timer_reference, process| {
+        timeout_after_half(milliseconds, barrier);
+
+        let message = Term::str_to_atom("different", DoNotCare).unwrap();
+        let timeout_message = timeout_message(timer_reference, message, process);
+
+        assert!(!has_message(process, timeout_message));
+
+        let milliseconds_remaining =
+            erlang::cancel_timer_1(timer_reference, process).expect("Timer could not be cancelled");
+
+        assert!(milliseconds_remaining.is_integer());
+        assert!(0.into_process(process) < milliseconds_remaining);
+        assert!(milliseconds_remaining <= (milliseconds / 2).into_process(process));
+
+        // again before timeout
+        assert_eq!(
+            erlang::cancel_timer_1(timer_reference, process),
+            Ok(false.into())
+        );
+
+        timeout_after_half(milliseconds, barrier);
+
+        assert!(!has_message(process, timeout_message));
+
+        // again after timeout
+        assert_eq!(
+            erlang::cancel_timer_1(timer_reference, process),
+            Ok(false.into())
+        );
+    });
+}
+
+#[test]
+fn with_timeout_returns_false_after_timeout_message_was_sent() {
+    with_timer(|milliseconds, barrier, timer_reference, process| {
+        timeout_after_half(milliseconds, barrier);
+        timeout_after_half(milliseconds, barrier);
+
+        let message = Term::str_to_atom("different", DoNotCare).unwrap();
+        let timeout_message = timeout_message(timer_reference, message, process);
+
+        assert!(
+            has_message(process, timeout_message),
+            "Mailbox does not contain {:?} and instead contains {:?}",
+            timeout_message,
+            process.mailbox.lock().unwrap()
+        );
+
+        assert_eq!(
+            erlang::cancel_timer_1(timer_reference, process),
+            Ok(false.into())
+        );
+
+        // again
+        assert_eq!(
+            erlang::cancel_timer_1(timer_reference, process),
+            Ok(false.into())
+        );
+    });
+}
+
+fn with_timer<F>(f: F)
+where
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
+{
+    let same_thread_process_arc = process::local::new();
+    let milliseconds: u64 = 100;
+
+    // no wait to receive implemented yet, so use barrier for signalling
+    let same_thread_barrier = Arc::new(Barrier::new(2));
+
+    let different_thread_same_thread_process_pid = same_thread_process_arc.pid.clone();
+    let different_thread_barrier = same_thread_barrier.clone();
+
+    let different_thread = thread::spawn(move || {
+        let different_thread_process_arc = process::local::new();
+
+        let timer_reference = erlang::start_timer_3(
+            milliseconds.into_process(&different_thread_process_arc),
+            different_thread_same_thread_process_pid,
+            Term::str_to_atom("different", DoNotCare).unwrap(),
+            different_thread_process_arc.clone(),
+        )
+        .unwrap();
+
+        erlang::send_2(
+            different_thread_same_thread_process_pid,
+            Term::slice_to_tuple(
+                &[
+                    Term::str_to_atom("timer_reference", DoNotCare).unwrap(),
+                    timer_reference,
+                ],
+                &different_thread_process_arc,
+            ),
+            &different_thread_process_arc,
+        )
+        .expect("Different thread could not send to same thread");
+
+        wait_for_message(&different_thread_barrier);
+        timeout_after_half(milliseconds, &different_thread_barrier);
+        timeout_after_half(milliseconds, &different_thread_barrier);
+    });
+
+    wait_for_message(&same_thread_barrier);
+
+    let timer_reference_tuple =
+        receive_message(&same_thread_process_arc).expect("Cross-thread receive failed");
+
+    let timer_reference = erlang::element_2(
+        timer_reference_tuple,
+        2.into_process(&same_thread_process_arc),
+        &same_thread_process_arc,
+    )
+    .unwrap();
+
+    f(
+        milliseconds,
+        &same_thread_barrier,
+        timer_reference,
+        &same_thread_process_arc,
+    );
+
+    different_thread
+        .join()
+        .expect("Could not join different thread");
+}
+
+fn timeout_after_half(milliseconds: Milliseconds, barrier: &Barrier) {
+    thread::sleep(Duration::from_millis(milliseconds / 2));
+    timer::timeout();
+    barrier.wait();
+}
+
+fn wait_for_message(barrier: &Barrier) {
+    barrier.wait();
+}

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_1/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_1/with_local_reference/with_timer/in_same_thread.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn without_timeout_returns_milliseconds_remaining_and_does_not_send_timeout_message() {
+    with_timer(|milliseconds, message, timer_reference, process| {
+        let half_milliseconds = milliseconds / 2;
+
+        thread::sleep(Duration::from_millis(half_milliseconds));
+        timer::timeout();
+
+        let timeout_message = timeout_message(timer_reference, message, process);
+
+        assert!(!has_message(process, timeout_message));
+
+        let first_result = erlang::cancel_timer_1(timer_reference, process);
+
+        assert!(first_result.is_ok());
+
+        let milliseconds_remaining = first_result.unwrap();
+
+        assert!(milliseconds_remaining.is_integer());
+        assert!(0.into_process(process) < milliseconds_remaining);
+        assert!(milliseconds_remaining <= half_milliseconds.into_process(process));
+
+        // again before timeout
+        assert_eq!(
+            erlang::cancel_timer_1(timer_reference, process),
+            Ok(false.into())
+        );
+
+        thread::sleep(Duration::from_millis(half_milliseconds + 1));
+        timer::timeout();
+
+        assert!(!has_message(process, timeout_message));
+
+        // again after timeout
+        assert_eq!(
+            erlang::cancel_timer_1(timer_reference, process),
+            Ok(false.into())
+        );
+    })
+}
+
+#[test]
+fn with_timeout_returns_false_after_timeout_message_was_sent() {
+    with_timer(|milliseconds, message, timer_reference, process| {
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        let timeout_message = timeout_message(timer_reference, message, process);
+
+        assert!(
+            has_message(process, timeout_message),
+            "Mailbox contains: {:?}",
+            process.mailbox.lock().unwrap()
+        );
+
+        assert_eq!(
+            erlang::cancel_timer_1(timer_reference, process),
+            Ok(false.into())
+        );
+
+        // again
+        assert_eq!(
+            erlang::cancel_timer_1(timer_reference, process),
+            Ok(false.into())
+        );
+    })
+}
+
+fn with_timer<F>(f: F)
+where
+    F: FnOnce(u64, Term, Term, &Process) -> (),
+{
+    let same_thread_process_arc = process::local::new();
+    let milliseconds: u64 = 100;
+
+    let message = Term::str_to_atom("message", DoNotCare).unwrap();
+    let timer_reference = erlang::start_timer_3(
+        milliseconds.into_process(&same_thread_process_arc),
+        same_thread_process_arc.pid,
+        message,
+        same_thread_process_arc.clone(),
+    )
+    .unwrap();
+
+    f(
+        milliseconds,
+        message,
+        timer_reference,
+        &same_thread_process_arc,
+    );
+}

--- a/lumen_runtime/src/otp/erlang/tests/ceil_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/ceil_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/concatenate_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/concatenate_2.rs
@@ -18,8 +18,8 @@ fn with_atom_errors_badarg() {
 #[test]
 fn with_local_reference_errors_badarg() {
     errors_badarg(|process| {
-        let list = Term::local_reference(&process);
-        let term = Term::local_reference(&process);
+        let list = Term::next_local_reference(process);
+        let term = Term::next_local_reference(process);
 
         (list, term)
     });

--- a/lumen_runtime/src/otp/erlang/tests/concatenate_2/with_empty_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/concatenate_2/with_empty_list.rs
@@ -10,7 +10,7 @@ fn with_atom_returns_atom() {
 
 #[test]
 fn with_local_reference_returns_local_reference() {
-    returns_term(|process| Term::local_reference(&process));
+    returns_term(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/concatenate_2/with_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/concatenate_2/with_list.rs
@@ -15,7 +15,7 @@ fn with_atom_return_improper_list_with_atom_as_tail() {
 #[test]
 fn with_local_reference_returns_improper_list_with_local_reference_as_tail() {
     with(|element, list, process| {
-        let term = Term::local_reference(&process);
+        let term = Term::next_local_reference(process);
 
         assert_eq!(
             erlang::concatenate_2(list, term, &process),

--- a/lumen_runtime/src/otp/erlang/tests/convert_time_unit_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/convert_time_unit_3.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/delete_element_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/delete_element_2.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/div_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/div_2.rs
@@ -11,7 +11,7 @@ fn with_atom_dividend_errors_badarith() {
 
 #[test]
 fn with_local_reference_dividend_errors_badarith() {
-    with_dividend_errors_badarith(|process| Term::local_reference(&process));
+    with_dividend_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/div_2/with_big_integer_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/div_2/with_big_integer_dividend.rs
@@ -7,7 +7,7 @@ fn with_atom_divisor_errors_badarith() {
 
 #[test]
 fn with_local_reference_divisor_errors_badarith() {
-    with_divisor_errors_badarith(|process| Term::local_reference(&process));
+    with_divisor_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/div_2/with_float_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/div_2/with_float_dividend.rs
@@ -7,7 +7,7 @@ fn with_atom_divisor_errors_badarith() {
 
 #[test]
 fn with_local_reference_divisor_errors_badarith() {
-    with_divisor_errors_badarith(|process| Term::local_reference(&process));
+    with_divisor_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/div_2/with_small_integer_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/div_2/with_small_integer_dividend.rs
@@ -7,7 +7,7 @@ fn with_atom_divisor_errors_badarith() {
 
 #[test]
 fn with_local_reference_divisor_errors_badarith() {
-    with_divisor_errors_badarith(|process| Term::local_reference(&process));
+    with_divisor_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/divide_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/divide_2.rs
@@ -11,7 +11,7 @@ fn with_atom_dividend_errors_badarith() {
 
 #[test]
 fn with_local_reference_dividend_errors_badarith() {
-    with_dividend_errors_badarith(|process| Term::local_reference(&process));
+    with_dividend_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/divide_2/with_big_integer_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/divide_2/with_big_integer_dividend.rs
@@ -7,7 +7,7 @@ fn with_atom_divisor_errors_badarith() {
 
 #[test]
 fn with_local_reference_divisor_errors_badarith() {
-    with_divisor_errors_badarith(|process| Term::local_reference(&process));
+    with_divisor_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/divide_2/with_float_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/divide_2/with_float_dividend.rs
@@ -7,7 +7,7 @@ fn with_atom_divisor_errors_badarith() {
 
 #[test]
 fn with_local_reference_divisor_errors_badarith() {
-    with_divisor_errors_badarith(|process| Term::local_reference(&process));
+    with_divisor_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/divide_2/with_small_integer_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/divide_2/with_small_integer_dividend.rs
@@ -7,7 +7,7 @@ fn with_atom_divisor_errors_badarith() {
 
 #[test]
 fn with_local_reference_divisor_errors_badarith() {
-    with_divisor_errors_badarith(|process| Term::local_reference(&process));
+    with_divisor_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/element_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/element_2.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tuple_errors_badarg(|process| Term::local_reference(&process));
+    with_tuple_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/error_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/error_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_atom_reason() {
 
 #[test]
 fn with_local_reference_errors_local_reference() {
-    errors(|process| Term::local_reference(&process));
+    errors(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/error_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/error_2.rs
@@ -19,7 +19,7 @@ fn with_atom_errors_with_atom_reason() {
 #[test]
 fn with_list_reference_errors_with_list_reference_reason() {
     with_process(|process| {
-        let reason = Term::local_reference(&process);
+        let reason = Term::next_local_reference(process);
         let arguments = Term::EMPTY_LIST;
 
         assert_error!(erlang::error_2(reason, arguments), reason, Some(arguments));

--- a/lumen_runtime/src/otp/erlang/tests/exit_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/exit_1.rs
@@ -11,7 +11,7 @@ fn with_atom_exits_with_atom_reason() {
 
 #[test]
 fn with_local_reference_exits_with_local_reference() {
-    exits(|process| Term::local_reference(&process));
+    exits(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/hd_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/hd_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/insert_element_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/insert_element_3.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tuple_errors_badarg(|process| Term::local_reference(&process));
+    with_tuple_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_atom_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_atom_1.rs
@@ -25,7 +25,7 @@ fn with_nil_is_true() {
 #[test]
 fn with_local_reference_is_false() {
     with_process(|process| {
-        let term = Term::local_reference(&process);
+        let term = Term::next_local_reference(process);
 
         assert_eq!(erlang::is_atom_1(term), false.into());
     });

--- a/lumen_runtime/src/otp/erlang/tests/is_binary_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_binary_1.rs
@@ -12,7 +12,7 @@ fn with_atom_is_false() {
 #[test]
 fn with_local_reference_is_false() {
     with_process(|process| {
-        let term = Term::local_reference(&process);
+        let term = Term::next_local_reference(process);
 
         assert_eq!(erlang::is_binary_1(term), false.into());
     });

--- a/lumen_runtime/src/otp/erlang/tests/is_bitstring_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_bitstring_1.rs
@@ -14,7 +14,7 @@ fn with_atom_is_false() {
 #[test]
 fn with_local_reference_is_false() {
     with_process(|process| {
-        let term = Term::local_reference(&process);
+        let term = Term::next_local_reference(process);
 
         assert_eq!(erlang::is_bitstring_1(term), false.into());
     });

--- a/lumen_runtime/src/otp/erlang/tests/is_boolean_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_boolean_1.rs
@@ -7,7 +7,7 @@ mod with_atom;
 #[test]
 fn with_local_reference_is_false() {
     with_process(|process| {
-        let term = Term::local_reference(&process);
+        let term = Term::next_local_reference(process);
 
         assert_eq!(erlang::is_boolean_1(term), false.into());
     });

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_atom_left.rs
@@ -40,7 +40,7 @@ fn with_greater_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_equal_or_less_than(|_, process| Term::local_reference(&process), true);
+    is_equal_or_less_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_big_integer_left.rs
@@ -64,7 +64,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_equal_or_less_than(|_, process| Term::local_reference(&process), true);
+    is_equal_or_less_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_empty_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_empty_list_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_equal_or_less_than(|_, process| Term::local_reference(&process), false);
+    is_equal_or_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_external_pid_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_equal_or_less_than(|_, process| Term::local_reference(&process), false);
+    is_equal_or_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_float_left.rs
@@ -43,7 +43,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_equal_or_less_than(|_, process| Term::local_reference(&process), true);
+    is_equal_or_less_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_heap_binary_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_equal_or_less_than(|_, process| Term::local_reference(&process), false);
+    is_equal_or_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_list_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_equal_or_less_than(|_, process| Term::local_reference(&process), false);
+    is_equal_or_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_local_pid_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_equal_or_less_than(|_, process| Term::local_reference(&process), false);
+    is_equal_or_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_local_reference_left.rs
@@ -25,10 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_lesser_local_reference_right_returns_false() {
-    is_equal_or_less_than(
-        |_, process| Term::number_to_local_reference(0, &process),
-        false,
-    );
+    is_equal_or_less_than(|_, process| Term::local_reference(0, process), false);
 }
 
 #[test]
@@ -38,18 +35,12 @@ fn with_same_local_reference_right_returns_true() {
 
 #[test]
 fn with_same_value_local_reference_right_returns_true() {
-    is_equal_or_less_than(
-        |_, process| Term::number_to_local_reference(1, &process),
-        true,
-    );
+    is_equal_or_less_than(|_, process| Term::local_reference(1, process), true);
 }
 
 #[test]
 fn with_greater_local_reference_right_returns_true() {
-    is_equal_or_less_than(
-        |_, process| Term::number_to_local_reference(2, &process),
-        true,
-    );
+    is_equal_or_less_than(|_, process| Term::local_reference(2, process), true);
 }
 
 #[test]
@@ -102,9 +93,5 @@ fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
     R: FnOnce(Term, &Process) -> Term,
 {
-    super::is_equal_or_less_than(
-        |process| Term::number_to_local_reference(1, &process),
-        right,
-        expected,
-    );
+    super::is_equal_or_less_than(|process| Term::local_reference(1, process), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_map_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_equal_or_less_than(|_, process| Term::local_reference(&process), false);
+    is_equal_or_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_small_integer_left.rs
@@ -58,7 +58,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_equal_or_less_than(|_, process| Term::local_reference(&process), true);
+    is_equal_or_less_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_subbinary_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_equal_or_less_than(|_, process| Term::local_reference(&process), false);
+    is_equal_or_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_tuple_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_equal_or_less_than(|_, process| Term::local_reference(&process), false);
+    is_equal_or_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_float_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_float_1.rs
@@ -12,7 +12,7 @@ fn with_atom_is_false() {
 #[test]
 fn with_local_reference_is_false() {
     with_process(|process| {
-        let term = Term::local_reference(&process);
+        let term = Term::next_local_reference(process);
 
         assert_eq!(erlang::is_float_1(term), false.into());
     });

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_atom_left.rs
@@ -40,7 +40,7 @@ fn with_greater_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_greater_than(|_, process| Term::local_reference(&process), false);
+    is_greater_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_big_integer_left.rs
@@ -64,7 +64,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_greater_than(|_, process| Term::local_reference(&process), false);
+    is_greater_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_empty_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_empty_list_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than(|_, process| Term::local_reference(&process), true);
+    is_greater_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_external_pid_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than(|_, process| Term::local_reference(&process), true);
+    is_greater_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_float_left.rs
@@ -43,7 +43,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_greater_than(|_, process| Term::local_reference(&process), false);
+    is_greater_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_heap_binary_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than(|_, process| Term::local_reference(&process), true);
+    is_greater_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_list_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than(|_, process| Term::local_reference(&process), true);
+    is_greater_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_local_pid_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than(|_, process| Term::local_reference(&process), true);
+    is_greater_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_local_reference_left.rs
@@ -25,10 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_greater_local_reference_right_returns_true() {
-    is_greater_than(
-        |_, process| Term::number_to_local_reference(0, &process),
-        true,
-    );
+    is_greater_than(|_, process| Term::local_reference(0, process), true);
 }
 
 #[test]
@@ -38,18 +35,12 @@ fn with_same_local_reference_right_returns_false() {
 
 #[test]
 fn with_same_value_local_reference_right_returns_false() {
-    is_greater_than(
-        |_, process| Term::number_to_local_reference(1, &process),
-        false,
-    );
+    is_greater_than(|_, process| Term::local_reference(1, process), false);
 }
 
 #[test]
 fn with_greater_local_reference_right_returns_false() {
-    is_greater_than(
-        |_, process| Term::number_to_local_reference(2, &process),
-        false,
-    );
+    is_greater_than(|_, process| Term::local_reference(2, process), false);
 }
 
 #[test]
@@ -102,9 +93,5 @@ fn is_greater_than<R>(right: R, expected: bool)
 where
     R: FnOnce(Term, &Process) -> Term,
 {
-    super::is_greater_than(
-        |process| Term::number_to_local_reference(1, &process),
-        right,
-        expected,
-    );
+    super::is_greater_than(|process| Term::local_reference(1, process), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_map_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than(|_, process| Term::local_reference(&process), true);
+    is_greater_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_small_integer_left.rs
@@ -58,7 +58,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_greater_than(|_, process| Term::local_reference(&process), false);
+    is_greater_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_subbinary_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than(|_, process| Term::local_reference(&process), true);
+    is_greater_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_tuple_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than(|_, process| Term::local_reference(&process), true);
+    is_greater_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_atom_left.rs
@@ -40,7 +40,7 @@ fn with_greater_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_greater_than_or_equal(|_, process| Term::local_reference(&process), false);
+    is_greater_than_or_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_big_integer_left.rs
@@ -64,7 +64,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_greater_than_or_equal(|_, process| Term::local_reference(&process), false);
+    is_greater_than_or_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_empty_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_empty_list_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than_or_equal(|_, process| Term::local_reference(&process), true);
+    is_greater_than_or_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_external_pid_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than_or_equal(|_, process| Term::local_reference(&process), true);
+    is_greater_than_or_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_float_left.rs
@@ -43,7 +43,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_greater_than_or_equal(|_, process| Term::local_reference(&process), false);
+    is_greater_than_or_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_heap_binary_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than_or_equal(|_, process| Term::local_reference(&process), true);
+    is_greater_than_or_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_list_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than_or_equal(|_, process| Term::local_reference(&process), true);
+    is_greater_than_or_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_local_pid_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than_or_equal(|_, process| Term::local_reference(&process), true);
+    is_greater_than_or_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_local_reference_left.rs
@@ -25,10 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_greater_local_reference_right_returns_true() {
-    is_greater_than_or_equal(
-        |_, process| Term::number_to_local_reference(0, &process),
-        true,
-    );
+    is_greater_than_or_equal(|_, process| Term::local_reference(0, process), true);
 }
 
 #[test]
@@ -38,18 +35,12 @@ fn with_same_local_reference_right_returns_true() {
 
 #[test]
 fn with_same_value_local_reference_right_returns_true() {
-    is_greater_than_or_equal(
-        |_, process| Term::number_to_local_reference(1, &process),
-        true,
-    );
+    is_greater_than_or_equal(|_, process| Term::local_reference(1, process), true);
 }
 
 #[test]
 fn with_greater_local_reference_right_returns_false() {
-    is_greater_than_or_equal(
-        |_, process| Term::number_to_local_reference(2, &process),
-        false,
-    );
+    is_greater_than_or_equal(|_, process| Term::local_reference(2, process), false);
 }
 
 #[test]
@@ -102,9 +93,5 @@ fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
     R: FnOnce(Term, &Process) -> Term,
 {
-    super::is_greater_than_or_equal(
-        |process| Term::number_to_local_reference(1, &process),
-        right,
-        expected,
-    );
+    super::is_greater_than_or_equal(|process| Term::local_reference(1, process), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_map_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than_or_equal(|_, process| Term::local_reference(&process), true);
+    is_greater_than_or_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_small_integer_left.rs
@@ -58,7 +58,7 @@ fn with_atom_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_greater_than_or_equal(|_, process| Term::local_reference(&process), false);
+    is_greater_than_or_equal(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_subbinary_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than_or_equal(|_, process| Term::local_reference(&process), true);
+    is_greater_than_or_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_tuple_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_greater_than_or_equal(|_, process| Term::local_reference(&process), true);
+    is_greater_than_or_equal(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_integer_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_integer_1.rs
@@ -12,7 +12,7 @@ fn with_atom_is_false() {
 #[test]
 fn with_local_reference_is_false() {
     with_process(|process| {
-        let term = Term::local_reference(&process);
+        let term = Term::next_local_reference(process);
 
         assert_eq!(erlang::is_integer_1(term), false.into());
     });

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_atom_left.rs
@@ -40,7 +40,7 @@ fn with_greater_atom_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_less_than(|_, process| Term::local_reference(&process), true);
+    is_less_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_big_integer_left.rs
@@ -64,7 +64,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_less_than(|_, process| Term::local_reference(&process), true);
+    is_less_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_empty_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_empty_list_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_less_than(|_, process| Term::local_reference(&process), false);
+    is_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_external_pid_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_less_than(|_, process| Term::local_reference(&process), false);
+    is_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_float_left.rs
@@ -43,7 +43,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_less_than(|_, process| Term::local_reference(&process), true);
+    is_less_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_heap_binary_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_less_than(|_, process| Term::local_reference(&process), false);
+    is_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_list_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_less_than(|_, process| Term::local_reference(&process), false);
+    is_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_local_pid_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_less_than(|_, process| Term::local_reference(&process), false);
+    is_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_local_reference_left.rs
@@ -25,10 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_lesser_local_reference_right_returns_false() {
-    is_less_than(
-        |_, process| Term::number_to_local_reference(0, &process),
-        false,
-    );
+    is_less_than(|_, process| Term::local_reference(0, process), false);
 }
 
 #[test]
@@ -38,18 +35,12 @@ fn with_same_local_reference_right_returns_false() {
 
 #[test]
 fn with_same_value_local_reference_right_returns_false() {
-    is_less_than(
-        |_, process| Term::number_to_local_reference(1, &process),
-        false,
-    );
+    is_less_than(|_, process| Term::local_reference(1, process), false);
 }
 
 #[test]
 fn with_greater_local_reference_right_returns_true() {
-    is_less_than(
-        |_, process| Term::number_to_local_reference(2, &process),
-        true,
-    );
+    is_less_than(|_, process| Term::local_reference(2, process), true);
 }
 
 #[test]
@@ -102,9 +93,5 @@ fn is_less_than<R>(right: R, expected: bool)
 where
     R: FnOnce(Term, &Process) -> Term,
 {
-    super::is_less_than(
-        |process| Term::number_to_local_reference(1, &process),
-        right,
-        expected,
-    );
+    super::is_less_than(|process| Term::local_reference(1, process), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_map_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_less_than(|_, process| Term::local_reference(&process), false);
+    is_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_small_integer_left.rs
@@ -58,7 +58,7 @@ fn with_atom_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    is_less_than(|_, process| Term::local_reference(&process), true);
+    is_less_than(|_, process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_subbinary_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_less_than(|_, process| Term::local_reference(&process), false);
+    is_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_tuple_left.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_false() {
 
 #[test]
 fn with_local_reference_right_returns_false() {
-    is_less_than(|_, process| Term::local_reference(&process), false);
+    is_less_than(|_, process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_list_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_list_1.rs
@@ -12,7 +12,7 @@ fn with_atom_is_false() {
 #[test]
 fn with_local_reference_is_false() {
     with_process(|process| {
-        let term = Term::local_reference(&process);
+        let term = Term::next_local_reference(process);
 
         assert_eq!(erlang::is_list_1(term), false.into());
     });

--- a/lumen_runtime/src/otp/erlang/tests/is_map_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_map_1.rs
@@ -12,7 +12,7 @@ fn with_atom_is_false() {
 #[test]
 fn with_local_reference_is_false() {
     with_process(|process| {
-        let term = Term::local_reference(&process);
+        let term = Term::next_local_reference(process);
 
         assert_eq!(erlang::is_map_1(term), false.into());
     });

--- a/lumen_runtime/src/otp/erlang/tests/is_map_key_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_map_key_2.rs
@@ -15,8 +15,8 @@ fn with_atom_errors_bad_map() {
 #[test]
 fn with_local_reference_errors_badmap() {
     with_key_and_map_errors_badmap(
-        |process| Term::local_reference(&process),
-        |process| Term::local_reference(&process),
+        |process| Term::next_local_reference(process),
+        |process| Term::next_local_reference(process),
     );
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/is_map_key_2/with_map.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_map_key_2/with_map.rs
@@ -25,8 +25,8 @@ fn with_atom_key() {
 #[test]
 fn with_local_reference_key() {
     with_process(|process| {
-        let key = Term::local_reference(&process);
-        let value = Term::local_reference(&process);
+        let key = Term::next_local_reference(process);
+        let value = Term::next_local_reference(process);
         let map_with_key = Term::slice_to_map(&[(key, value)], &process);
 
         assert_eq!(

--- a/lumen_runtime/src/otp/erlang/tests/is_number_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_number_1.rs
@@ -9,7 +9,7 @@ fn with_atom_is_false() {
 
 #[test]
 fn with_local_reference_is_false() {
-    is_number(|process| Term::local_reference(&process), false);
+    is_number(|process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_pid_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_pid_1.rs
@@ -9,7 +9,7 @@ fn with_atom_is_false() {
 
 #[test]
 fn with_local_reference_is_false() {
-    is_pid(|process| Term::local_reference(&process), false);
+    is_pid(|process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_record_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_record_2.rs
@@ -13,7 +13,7 @@ fn with_atom_is_false() {
 #[test]
 fn with_local_reference_is_false() {
     let process = process::local::new();
-    let term = Term::local_reference(&process);
+    let term = Term::next_local_reference(&process);
     let record_tag = Term::str_to_atom("record_tag", DoNotCare).unwrap();
 
     assert_eq!(erlang::is_record_2(term, record_tag), Ok(false.into()));

--- a/lumen_runtime/src/otp/erlang/tests/is_record_2/with_tuple.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_record_2/with_tuple.rs
@@ -18,7 +18,7 @@ fn with_atom_record_tag() {
 
 #[test]
 fn with_local_reference_record_tag_errors_badarg() {
-    with_record_tag_errors_badarg(|process| Term::local_reference(&process));
+    with_record_tag_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_record_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_record_3.rs
@@ -11,7 +11,7 @@ fn with_atom_is_false() {
 
 #[test]
 fn with_local_reference_is_false() {
-    is_not_record_with_term(|process| Term::local_reference(&process));
+    is_not_record_with_term(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_record_3/with_tuple.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_record_3/with_tuple.rs
@@ -8,7 +8,7 @@ mod with_atom_record_tag;
 
 #[test]
 fn with_local_reference_record_tag_errors_badarg() {
-    with_record_tag_errors_badarg(|process| Term::local_reference(&process));
+    with_record_tag_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_record_3/with_tuple/with_atom_record_tag.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_record_3/with_tuple/with_atom_record_tag.rs
@@ -11,7 +11,7 @@ fn with_atom_size_errors_badarg() {
 
 #[test]
 fn with_local_reference_size_errors_badarg() {
-    with_size_errors_badarg(|process| Term::local_reference(&process));
+    with_size_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_reference_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_reference_1.rs
@@ -9,7 +9,7 @@ fn with_atom_is_false() {
 
 #[test]
 fn with_local_reference_is_true() {
-    is_reference(|process| Term::local_reference(&process), true);
+    is_reference(|process| Term::next_local_reference(process), true);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/is_tuple_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_tuple_1.rs
@@ -9,7 +9,7 @@ fn with_atom_is_false() {
 
 #[test]
 fn with_local_reference_is_false() {
-    is_tuple(|process| Term::local_reference(&process), false);
+    is_tuple(|process| Term::next_local_reference(process), false);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/length_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/length_1.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_atom_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_atom_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list.rs
@@ -17,7 +17,13 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::cons(Term::local_reference(&process), Term::EMPTY_LIST, &process))
+    errors_badarg(|process| {
+        Term::cons(
+            Term::next_local_reference(process),
+            Term::EMPTY_LIST,
+            &process,
+        )
+    })
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_binary_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_binary_subbinary.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_byte.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_byte.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_heap_binary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_heap_binary.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list.rs
@@ -24,7 +24,13 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::cons(Term::local_reference(&process), Term::EMPTY_LIST, &process))
+    errors_badarg(|process| {
+        Term::cons(
+            Term::next_local_reference(process),
+            Term::EMPTY_LIST,
+            &process,
+        )
+    })
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_0_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_0_bit_subbinary.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_1_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_1_bit_subbinary.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_2_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_2_bit_subbinary.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_3_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_3_bit_subbinary.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_4_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_4_bit_subbinary.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_5_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_5_bit_subbinary.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_6_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_6_bit_subbinary.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_7_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_7_bit_subbinary.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_byte.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_byte.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_heap_binary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_heap_binary.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_tail_errors_badarg(|process| Term::local_reference(&process));
+    with_tail_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_existing_atom_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_existing_atom_1.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_pid_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_pid_1.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/list_to_tuple_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_tuple_1.rs
@@ -7,7 +7,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/map_get_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/map_get_2.rs
@@ -15,8 +15,8 @@ fn with_atom_errors_badmap() {
 #[test]
 fn with_local_reference_errors_badmap() {
     with_key_and_map_errors_badmap(
-        |process| Term::local_reference(&process),
-        |process| Term::local_reference(&process),
+        |process| Term::next_local_reference(process),
+        |process| Term::next_local_reference(process),
     );
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/map_get_2/with_map.rs
+++ b/lumen_runtime/src/otp/erlang/tests/map_get_2/with_map.rs
@@ -22,8 +22,8 @@ fn with_atom_key() {
 #[test]
 fn with_local_reference_key() {
     with_process(|process| {
-        let key = Term::local_reference(&process);
-        let value = Term::local_reference(&process);
+        let key = Term::next_local_reference(process);
+        let value = Term::next_local_reference(process);
         let map_with_key = Term::slice_to_map(&[(key, value)], &process);
 
         assert_eq!(erlang::map_get_2(key, map_with_key, &process), Ok(value));

--- a/lumen_runtime/src/otp/erlang/tests/map_size_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/map_size_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badmap() {
 
 #[test]
 fn with_local_reference_errors_badmap() {
-    errors_badmap(|process| Term::local_reference(&process));
+    errors_badmap(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_atom_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_atom_first.rs
@@ -43,7 +43,7 @@ fn with_greater_atom_returns_second() {
 
 #[test]
 fn with_local_reference_second_returns_second() {
-    max(|_, process| Term::local_reference(&process), Second);
+    max(|_, process| Term::next_local_reference(process), Second);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_big_integer_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_big_integer_first.rs
@@ -67,7 +67,7 @@ fn with_atom_second_returns_second() {
 
 #[test]
 fn with_local_reference_second_returns_second() {
-    max(|_, process| Term::local_reference(&process), Second);
+    max(|_, process| Term::next_local_reference(process), Second);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_empty_list_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_empty_list_first.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_first() {
 
 #[test]
 fn with_local_reference_second_returns_first() {
-    max(|_, process| Term::local_reference(&process), First);
+    max(|_, process| Term::next_local_reference(process), First);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_external_pid_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_external_pid_first.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_first() {
 
 #[test]
 fn with_local_reference_second_returns_first() {
-    max(|_, process| Term::local_reference(&process), First);
+    max(|_, process| Term::next_local_reference(process), First);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_float_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_float_first.rs
@@ -46,7 +46,7 @@ fn with_atom_second_returns_second() {
 
 #[test]
 fn with_local_reference_second_returns_second() {
-    max(|_, process| Term::local_reference(&process), Second);
+    max(|_, process| Term::next_local_reference(process), Second);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_heap_binary_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_heap_binary_first.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_first() {
 
 #[test]
 fn with_local_reference_second_returns_first() {
-    max(|_, process| Term::local_reference(&process), First);
+    max(|_, process| Term::next_local_reference(process), First);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_list_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_list_first.rs
@@ -28,7 +28,7 @@ fn with_atom_returns_first() {
 
 #[test]
 fn with_local_reference_second_returns_first() {
-    max(|_, process| Term::local_reference(&process), First);
+    max(|_, process| Term::next_local_reference(process), First);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_local_pid_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_local_pid_first.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_first() {
 
 #[test]
 fn with_local_reference_second_returns_first() {
-    max(|_, process| Term::local_reference(&process), First);
+    max(|_, process| Term::next_local_reference(process), First);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_local_reference_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_local_reference_first.rs
@@ -25,10 +25,7 @@ fn with_atom_returns_first() {
 
 #[test]
 fn with_lesser_local_reference_second_returns_first() {
-    max(
-        |_, process| Term::number_to_local_reference(0, &process),
-        First,
-    );
+    max(|_, process| Term::local_reference(0, process), First);
 }
 
 #[test]
@@ -38,18 +35,12 @@ fn with_same_local_reference_second_returns_first() {
 
 #[test]
 fn with_same_value_local_reference_second_returns_first() {
-    max(
-        |_, process| Term::number_to_local_reference(1, &process),
-        First,
-    );
+    max(|_, process| Term::local_reference(1, process), First);
 }
 
 #[test]
 fn with_greater_local_reference_second_returns_second() {
-    max(
-        |_, process| Term::number_to_local_reference(2, &process),
-        Second,
-    );
+    max(|_, process| Term::local_reference(2, process), Second);
 }
 
 #[test]
@@ -102,9 +93,5 @@ fn max<R>(second: R, which: FirstSecond)
 where
     R: FnOnce(Term, &Process) -> Term,
 {
-    super::max(
-        |process| Term::number_to_local_reference(1, &process),
-        second,
-        which,
-    );
+    super::max(|process| Term::local_reference(1, process), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_map_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_map_first.rs
@@ -28,7 +28,7 @@ fn with_atom_returns_first() {
 
 #[test]
 fn with_local_reference_second_returns_first() {
-    max(|_, process| Term::local_reference(&process), First);
+    max(|_, process| Term::next_local_reference(process), First);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_small_integer_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_small_integer_first.rs
@@ -61,7 +61,7 @@ fn with_atom_second_returns_second() {
 
 #[test]
 fn with_local_reference_second_returns_second() {
-    max(|_, process| Term::local_reference(&process), Second);
+    max(|_, process| Term::next_local_reference(process), Second);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_subbinary_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_subbinary_first.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_first() {
 
 #[test]
 fn with_local_reference_second_returns_first() {
-    max(|_, process| Term::local_reference(&process), First);
+    max(|_, process| Term::next_local_reference(process), First);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_tuple_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_tuple_first.rs
@@ -28,7 +28,7 @@ fn with_atom_returns_first() {
 
 #[test]
 fn with_local_reference_second_returns_first() {
-    max(|_, process| Term::local_reference(&process), First);
+    max(|_, process| Term::next_local_reference(process), First);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_atom_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_atom_first.rs
@@ -46,7 +46,7 @@ fn with_greater_atom_returns_first() {
 
 #[test]
 fn with_local_reference_second_returns_first() {
-    min(|_, process| Term::local_reference(&process), First);
+    min(|_, process| Term::next_local_reference(process), First);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_big_integer_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_big_integer_first.rs
@@ -67,7 +67,7 @@ fn with_atom_second_returns_first() {
 
 #[test]
 fn with_local_reference_second_returns_first() {
-    min(|_, process| Term::local_reference(&process), First);
+    min(|_, process| Term::next_local_reference(process), First);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_empty_list_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_empty_list_first.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_second() {
 
 #[test]
 fn with_local_reference_second_returns_second() {
-    min(|_, process| Term::local_reference(&process), Second);
+    min(|_, process| Term::next_local_reference(process), Second);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_external_pid_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_external_pid_first.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_second() {
 
 #[test]
 fn with_local_reference_second_returns_second() {
-    min(|_, process| Term::local_reference(&process), Second);
+    min(|_, process| Term::next_local_reference(process), Second);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_float_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_float_first.rs
@@ -46,7 +46,7 @@ fn with_atom_second_returns_first() {
 
 #[test]
 fn with_local_reference_second_returns_first() {
-    min(|_, process| Term::local_reference(&process), First);
+    min(|_, process| Term::next_local_reference(process), First);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_heap_binary_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_heap_binary_first.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_second() {
 
 #[test]
 fn with_local_reference_second_returns_second() {
-    min(|_, process| Term::local_reference(&process), Second);
+    min(|_, process| Term::next_local_reference(process), Second);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_list_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_list_first.rs
@@ -28,7 +28,7 @@ fn with_atom_returns_second() {
 
 #[test]
 fn with_local_reference_second_returns_second() {
-    min(|_, process| Term::local_reference(&process), Second);
+    min(|_, process| Term::next_local_reference(process), Second);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_local_pid_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_local_pid_first.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_second() {
 
 #[test]
 fn with_local_reference_second_returns_second() {
-    min(|_, process| Term::local_reference(&process), Second);
+    min(|_, process| Term::next_local_reference(process), Second);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_local_reference_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_local_reference_first.rs
@@ -25,10 +25,7 @@ fn with_atom_returns_second() {
 
 #[test]
 fn with_lesser_local_reference_second_returns_second() {
-    min(
-        |_, process| Term::number_to_local_reference(0, &process),
-        Second,
-    );
+    min(|_, process| Term::local_reference(0, process), Second);
 }
 
 #[test]
@@ -38,18 +35,12 @@ fn with_same_local_reference_second_returns_first() {
 
 #[test]
 fn with_same_value_local_reference_second_returns_first() {
-    min(
-        |_, process| Term::number_to_local_reference(1, &process),
-        First,
-    );
+    min(|_, process| Term::local_reference(1, process), First);
 }
 
 #[test]
 fn with_greater_local_reference_second_returns_first() {
-    min(
-        |_, process| Term::number_to_local_reference(2, &process),
-        First,
-    );
+    min(|_, process| Term::local_reference(2, process), First);
 }
 
 #[test]
@@ -102,9 +93,5 @@ fn min<R>(second: R, which: FirstSecond)
 where
     R: FnOnce(Term, &Process) -> Term,
 {
-    super::min(
-        |process| Term::number_to_local_reference(1, &process),
-        second,
-        which,
-    );
+    super::min(|process| Term::local_reference(1, process), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_map_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_map_first.rs
@@ -28,7 +28,7 @@ fn with_atom_returns_second() {
 
 #[test]
 fn with_local_reference_second_returns_second() {
-    min(|_, process| Term::local_reference(&process), Second);
+    min(|_, process| Term::next_local_reference(process), Second);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_small_integer_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_small_integer_first.rs
@@ -61,7 +61,7 @@ fn with_atom_second_returns_first() {
 
 #[test]
 fn with_local_reference_second_returns_first() {
-    min(|_, process| Term::local_reference(&process), First);
+    min(|_, process| Term::next_local_reference(process), First);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_subbinary_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_subbinary_first.rs
@@ -25,7 +25,7 @@ fn with_atom_returns_second() {
 
 #[test]
 fn with_local_reference_second_returns_second() {
-    min(|_, process| Term::local_reference(&process), Second);
+    min(|_, process| Term::next_local_reference(process), Second);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_tuple_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_tuple_first.rs
@@ -28,7 +28,7 @@ fn with_atom_returns_second() {
 
 #[test]
 fn with_local_reference_second_returns_second() {
-    min(|_, process| Term::local_reference(&process), Second);
+    min(|_, process| Term::next_local_reference(process), Second);
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/monotonic_time_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/monotonic_time_1.rs
@@ -10,7 +10,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/multiply_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/multiply_2.rs
@@ -11,7 +11,7 @@ fn with_atom_multiplier_errors_badarith() {
 
 #[test]
 fn with_local_reference_multiplier_errors_badarith() {
-    with_multiplier_errors_badarith(|process| Term::local_reference(&process));
+    with_multiplier_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/multiply_2/with_big_integer_multiplier.rs
+++ b/lumen_runtime/src/otp/erlang/tests/multiply_2/with_big_integer_multiplier.rs
@@ -7,7 +7,7 @@ fn with_atom_multiplicand_errors_badarith() {
 
 #[test]
 fn with_local_reference_multiplicand_errors_badarith() {
-    with_multiplicand_errors_badarith(|process| Term::local_reference(&process));
+    with_multiplicand_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/multiply_2/with_float_multiplier.rs
+++ b/lumen_runtime/src/otp/erlang/tests/multiply_2/with_float_multiplier.rs
@@ -7,7 +7,7 @@ fn with_atom_multiplicand_errors_badarith() {
 
 #[test]
 fn with_local_reference_multiplicand_errors_badarith() {
-    with_multiplicand_errors_badarith(|process| Term::local_reference(&process));
+    with_multiplicand_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/multiply_2/with_small_integer_multiplier.rs
+++ b/lumen_runtime/src/otp/erlang/tests/multiply_2/with_small_integer_multiplier.rs
@@ -7,7 +7,7 @@ fn with_atom_multiplicand_errors_badarith() {
 
 #[test]
 fn with_local_reference_multiplicand_errors_badarith() {
-    with_multiplicand_errors_badarith(|process| Term::local_reference(&process));
+    with_multiplicand_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/negate_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/negate_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarith() {
 
 #[test]
 fn with_local_reference_errors_badarith() {
-    errors_badarith(|process| Term::local_reference(&process));
+    errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/not_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/not_1.rs
@@ -17,7 +17,7 @@ fn with_true_returns_false() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/number_or_badarith_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/number_or_badarith_1.rs
@@ -11,7 +11,7 @@ fn with_atom_errors_badarith() {
 
 #[test]
 fn with_local_reference_errors_badarith() {
-    errors_badarith(|process| Term::local_reference(&process));
+    errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/or_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/or_2.rs
@@ -10,7 +10,7 @@ fn with_atom_left_errors_badarg() {
 
 #[test]
 fn with_local_reference_left_errors_badarg() {
-    with_left_errors_badarg(|process| Term::local_reference(&process));
+    with_left_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/or_2/with_false_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/or_2/with_false_left.rs
@@ -21,7 +21,7 @@ fn with_true_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_errors_badarg() {
-    with_right_errors_badarg(|process| Term::local_reference(&process));
+    with_right_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/or_2/with_true_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/or_2/with_true_left.rs
@@ -21,7 +21,7 @@ fn with_true_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_errors_badarg() {
-    with_right_errors_badarg(|process| Term::local_reference(&process));
+    with_right_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/orelse_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/orelse_2.rs
@@ -10,7 +10,7 @@ fn with_atom_left_errors_badarg() {
 
 #[test]
 fn with_local_reference_left_errors_badarg() {
-    with_left_errors_badarg(|process| Term::local_reference(&process));
+    with_left_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/orelse_2/with_false_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/orelse_2/with_false_left.rs
@@ -17,7 +17,7 @@ fn with_true_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    with_right_returns_right(|process| Term::local_reference(&process));
+    with_right_returns_right(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/orelse_2/with_true_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/orelse_2/with_true_left.rs
@@ -17,7 +17,7 @@ fn with_true_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_returns_true() {
-    with_right_returns_true(|process| Term::local_reference(&process));
+    with_right_returns_true(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/raise_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/raise_3.rs
@@ -8,7 +8,7 @@ mod with_atom_class;
 
 #[test]
 fn with_local_reference_class_errors_badarg() {
-    with_class_errors_badarg(|process| Term::local_reference(&process));
+    with_class_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/error.rs
+++ b/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/error.rs
@@ -4,7 +4,7 @@ mod with_list_stacktrace;
 
 #[test]
 fn with_local_reference_stacktrace_errors_badarg() {
-    with_stacktrace_errors_badarg(|process| Term::local_reference(&process));
+    with_stacktrace_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/exit.rs
+++ b/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/exit.rs
@@ -4,7 +4,7 @@ mod with_list_stacktrace;
 
 #[test]
 fn with_local_reference_stacktrace_errors_badarg() {
-    with_stacktrace_errors_badarg(|process| Term::local_reference(&process));
+    with_stacktrace_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/throw.rs
+++ b/lumen_runtime/src/otp/erlang/tests/raise_3/with_atom_class/throw.rs
@@ -4,7 +4,7 @@ mod with_list_stacktrace;
 
 #[test]
 fn with_local_reference_stacktrace_errors_badarg() {
-    with_stacktrace_errors_badarg(|process| Term::local_reference(&process));
+    with_stacktrace_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/register_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/register_2.rs
@@ -4,7 +4,7 @@ mod with_atom_name;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/rem_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/rem_2.rs
@@ -11,7 +11,7 @@ fn with_atom_dividend_errors_badarith() {
 
 #[test]
 fn with_local_reference_dividend_errors_badarith() {
-    with_dividend_errors_badarith(|process| Term::local_reference(&process));
+    with_dividend_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/rem_2/with_big_integer_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/rem_2/with_big_integer_dividend.rs
@@ -7,7 +7,7 @@ fn with_atom_divisor_errors_badarith() {
 
 #[test]
 fn with_local_reference_divisor_errors_badarith() {
-    with_divisor_errors_badarith(|process| Term::local_reference(&process));
+    with_divisor_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/rem_2/with_float_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/rem_2/with_float_dividend.rs
@@ -7,7 +7,7 @@ fn with_atom_divisor_errors_badarith() {
 
 #[test]
 fn with_local_reference_divisor_errors_badarith() {
-    with_divisor_errors_badarith(|process| Term::local_reference(&process));
+    with_divisor_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/rem_2/with_small_integer_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/rem_2/with_small_integer_dividend.rs
@@ -7,7 +7,7 @@ fn with_atom_divisor_errors_badarith() {
 
 #[test]
 fn with_local_reference_divisor_errors_badarith() {
-    with_divisor_errors_badarith(|process| Term::local_reference(&process));
+    with_divisor_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2.rs
@@ -8,7 +8,7 @@ mod with_tuple_destination;
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_different_process/with_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_heap_message_to_mailbox_and_returns_message() {
     with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_heap_message_to_mailbox_and_returns_message() {
     with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_different_process/without_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_adds_process_message_to_mailbox_and_returns_message() {
     with_adds_process_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_adds_process_message_to_mailbox_and_returns_message() {
     with_adds_process_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/registered/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_message() {
     with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_message() {
     with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_atom_destination/unregistered.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(&process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(&process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_different_process/with_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_adds_heap_message_to_mailbox_and_returns_message() {
     with_adds_heap_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_adds_heap_message_to_mailbox_and_returns_message() {
     with_adds_heap_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_different_process/without_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_message() {
     with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_message() {
     with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_message() {
     with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_message() {
     with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_local_pid_destination/without_process.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_message() {
-    with_message_returns_message(|process| Term::local_reference(&process));
+    with_message_returns_message(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_message() {
-    with_message_returns_message(|process| Term::local_reference(&process));
+    with_message_returns_message(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2.rs
@@ -4,7 +4,7 @@ mod with_atom_name;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name.rs
@@ -4,7 +4,7 @@ mod with_atom_node;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_different_node.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_different_node.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_panics_unimplemented() {
-    with_message_panics_unimplemented(|process| Term::local_reference(&process));
+    with_message_panics_unimplemented(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_panics_unimplemented() {
-    with_message_panics_unimplemented(|process| Term::local_reference(&process));
+    with_message_panics_unimplemented(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/with_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_heap_message_to_mailbox_and_returns_message() {
     with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_heap_message_to_mailbox_and_returns_message() {
     with_message_adds_heap_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_message() {
     with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_message() {
     with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_message() {
     with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_message() {
     with_message_adds_process_message_to_mailbox_and_returns_message(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/unregistered.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_message() {
-    with_message_returns_message(|process| Term::local_reference(&process));
+    with_message_returns_message(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_message() {
-    with_message_returns_message(|process| Term::local_reference(&process));
+    with_message_returns_message(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3.rs
@@ -10,7 +10,7 @@ fn with_atom_options_errors_badarg() {
 
 #[test]
 fn with_local_reference_options_errors_badarg() {
-    with_options_errors_badarg(|process| Term::local_reference(&process));
+    with_options_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options.rs
@@ -8,7 +8,7 @@ mod with_tuple_destination;
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_atom_destination/registered/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_atom_destination/registered/with_different_process/with_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_atom_destination/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_atom_destination/registered/with_different_process/without_locked.rs
@@ -2,12 +2,16 @@ use super::*;
 
 #[test]
 fn with_atom_adds_process_message_to_mailbox_and_returns_ok() {
-    with_adds_process_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_process_message_to_mailbox_and_returns_ok(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
 fn with_local_reference_adds_process_message_to_mailbox_and_returns_ok() {
-    with_adds_process_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_process_message_to_mailbox_and_returns_ok(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_atom_destination/registered/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_atom_destination/unregistered.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(&process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(&process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_local_pid_destination/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_local_pid_destination/with_different_process/with_locked.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_adds_heap_message_to_mailbox_and_returns_ok() {
-    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_adds_heap_message_to_mailbox_and_returns_ok() {
-    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_local_pid_destination/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_local_pid_destination/with_different_process/without_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_local_pid_destination/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_local_pid_destination/without_process.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2.rs
@@ -4,7 +4,7 @@ mod with_atom_name;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name.rs
@@ -4,7 +4,7 @@ mod with_atom_node;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_different_node.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_different_node.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_panics_unimplemented() {
-    with_message_panics_unimplemented(|process| Term::local_reference(&process));
+    with_message_panics_unimplemented(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_panics_unimplemented() {
-    with_message_panics_unimplemented(|process| Term::local_reference(&process));
+    with_message_panics_unimplemented(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/with_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_empty_list_options/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/unregistered.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_invalid_option.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_invalid_option.rs
@@ -7,7 +7,7 @@ fn with_atom_option_errors_badarg() {
 
 #[test]
 fn with_local_reference_option_errors_badarg() {
-    with_option_errors_badarg(|process| Term::local_reference(&process));
+    with_option_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect.rs
@@ -8,7 +8,7 @@ mod with_tuple_destination;
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_atom_destination/registered/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_atom_destination/registered/with_different_process/with_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_atom_destination/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_atom_destination/registered/with_different_process/without_locked.rs
@@ -2,12 +2,16 @@ use super::*;
 
 #[test]
 fn with_atom_adds_process_message_to_mailbox_and_returns_ok() {
-    with_adds_process_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_process_message_to_mailbox_and_returns_ok(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
 fn with_local_reference_adds_process_message_to_mailbox_and_returns_ok() {
-    with_adds_process_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_process_message_to_mailbox_and_returns_ok(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_atom_destination/registered/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_atom_destination/unregistered.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(&process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(&process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_local_pid_destination/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_local_pid_destination/with_different_process/with_locked.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_adds_heap_message_to_mailbox_and_returns_ok() {
-    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_adds_heap_message_to_mailbox_and_returns_ok() {
-    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_local_pid_destination/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_local_pid_destination/with_different_process/without_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_local_pid_destination/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_local_pid_destination/without_process.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2.rs
@@ -4,7 +4,7 @@ mod with_atom_name;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name.rs
@@ -4,7 +4,7 @@ mod with_atom_node;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_different_node.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_different_node.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_noconnect() {
-    with_message_returns_noconnect(|process| Term::local_reference(&process));
+    with_message_returns_noconnect(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_noconnect() {
-    with_message_returns_noconnect(|process| Term::local_reference(&process));
+    with_message_returns_noconnect(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/with_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/unregistered.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend.rs
@@ -8,7 +8,7 @@ mod with_tuple_destination;
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_atom_destination/registered/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_atom_destination/registered/with_different_process/with_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_atom_destination/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_atom_destination/registered/with_different_process/without_locked.rs
@@ -2,12 +2,16 @@ use super::*;
 
 #[test]
 fn with_atom_adds_process_message_to_mailbox_and_returns_ok() {
-    with_adds_process_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_process_message_to_mailbox_and_returns_ok(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
 fn with_local_reference_adds_process_message_to_mailbox_and_returns_ok() {
-    with_adds_process_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_process_message_to_mailbox_and_returns_ok(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_atom_destination/registered/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_atom_destination/unregistered.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(&process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(&process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_local_pid_destination/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_local_pid_destination/with_different_process/with_locked.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_adds_heap_message_to_mailbox_and_returns_ok() {
-    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_adds_heap_message_to_mailbox_and_returns_ok() {
-    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_local_pid_destination/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_local_pid_destination/with_different_process/without_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_local_pid_destination/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_local_pid_destination/without_process.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2.rs
@@ -4,7 +4,7 @@ mod with_atom_name;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name.rs
@@ -4,7 +4,7 @@ mod with_atom_node;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_different_node.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_different_node.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_noconnect() {
-    with_message_returns_noconnect(|process| Term::local_reference(&process));
+    with_message_returns_noconnect(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_noconnect() {
-    with_message_returns_noconnect(|process| Term::local_reference(&process));
+    with_message_returns_noconnect(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/with_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_noconnect_and_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/unregistered.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend.rs
@@ -8,7 +8,7 @@ mod with_tuple_destination;
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_atom_destination/registered/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_atom_destination/registered/with_different_process/with_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_atom_destination/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_atom_destination/registered/with_different_process/without_locked.rs
@@ -2,12 +2,16 @@ use super::*;
 
 #[test]
 fn with_atom_adds_process_message_to_mailbox_and_returns_ok() {
-    with_adds_process_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_process_message_to_mailbox_and_returns_ok(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
 fn with_local_reference_adds_process_message_to_mailbox_and_returns_ok() {
-    with_adds_process_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_process_message_to_mailbox_and_returns_ok(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_atom_destination/registered/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_atom_destination/unregistered.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(&process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(&process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_local_pid_destination/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_local_pid_destination/with_different_process/with_locked.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_adds_heap_message_to_mailbox_and_returns_ok() {
-    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_adds_heap_message_to_mailbox_and_returns_ok() {
-    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::local_reference(&process));
+    with_adds_heap_message_to_mailbox_and_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_local_pid_destination/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_local_pid_destination/with_different_process/without_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_local_pid_destination/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_local_pid_destination/without_process.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2.rs
@@ -4,7 +4,7 @@ mod with_atom_name;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name.rs
@@ -4,7 +4,7 @@ mod with_atom_node;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_different_node.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_different_node.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_nosuspend() {
-    with_message_returns_nosuspend(|process| Term::local_reference(&process));
+    with_message_returns_nosuspend(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_nosuspend() {
-    with_message_returns_nosuspend(|process| Term::local_reference(&process));
+    with_message_returns_nosuspend(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/with_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/with_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_heap_message_to_mailbox_and_returns_ok() {
     with_message_adds_heap_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_different_process/without_locked.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/registered/with_same_process.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn with_atom_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 
 #[test]
 fn with_local_reference_message_adds_process_message_to_mailbox_and_returns_ok() {
     with_message_adds_process_message_to_mailbox_and_returns_ok(|process| {
-        Term::local_reference(&process)
+        Term::next_local_reference(process)
     });
 }
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_list_options/with_nosuspend/with_tuple_destination/with_arity_2/with_atom_name/with_atom_node/with_same_node/unregistered.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[test]
 fn with_atom_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]
 fn with_local_reference_message_returns_ok() {
-    with_message_returns_ok(|process| Term::local_reference(&process));
+    with_message_returns_ok(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/setelement_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/setelement_3.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/size_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/size_1.rs
@@ -11,7 +11,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/split_binary_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/split_binary_2.rs
@@ -13,7 +13,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    with_binary_errors_badarg(|process| Term::local_reference(&process));
+    with_binary_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/split_binary_2/with_heap_binary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/split_binary_2/with_heap_binary.rs
@@ -9,7 +9,7 @@ fn with_atom_position_errors_badarg() {
 
 #[test]
 fn with_local_reference_position_errors_badarg() {
-    with_position_errors_badarg(|process| Term::local_reference(&process));
+    with_position_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/split_binary_2/with_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/split_binary_2/with_subbinary.rs
@@ -9,7 +9,7 @@ fn with_atom_position_errors_badarg() {
 
 #[test]
 fn with_local_reference_position_errors_badarg() {
-    with_position_errors_badarg(|process| Term::local_reference(&process));
+    with_position_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3.rs
@@ -17,7 +17,7 @@ fn with_atom_time_errors_badarg() {
 
 #[test]
 fn with_local_reference_time_errors_badarg() {
-    with_time_errors_badarg(|process| Term::local_reference(&process));
+    with_time_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -105,14 +107,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -100,14 +102,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -100,14 +102,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -95,19 +97,11 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 
         thread::sleep(Duration::from_millis(milliseconds + 1));
-
         timer::timeout();
 
         assert!(has_message(&process_arc, timeout_message));

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/at_once/with_local_pid_destination/without_process.rs
@@ -20,7 +20,7 @@ fn with_big_integer_message_does_not_panic_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_does_not_panic_when_timer_expires() {
-    does_not_panic_when_timer_expires(|process| Term::local_reference(process));
+    does_not_panic_when_timer_expires(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -105,14 +107,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -100,14 +102,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -100,14 +102,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -95,14 +97,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/later/with_local_pid_destination/without_process.rs
@@ -22,7 +22,7 @@ fn with_big_integer_message_does_not_panic_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_does_not_panic_when_timer_expires() {
-    with_message_does_not_panic_when_timer_expires(|process| Term::local_reference(process));
+    with_message_does_not_panic_when_timer_expires(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -105,14 +107,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -100,14 +102,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -100,14 +102,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -95,14 +97,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/long_term/with_local_pid_destination/without_process.rs
@@ -22,7 +22,7 @@ fn with_big_integer_message_does_not_panic_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_does_not_panic_when_timer_expires() {
-    with_message_does_not_panic_when_timer_expires(|process| Term::local_reference(process));
+    with_message_does_not_panic_when_timer_expires(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -105,14 +107,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -100,14 +102,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -100,14 +102,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -95,14 +97,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_3/with_small_integer_time/soon/with_local_pid_destination/without_process.rs
@@ -22,7 +22,7 @@ fn with_big_integer_message_does_not_panic_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_does_not_panic_when_timer_expires() {
-    with_message_does_not_panic_when_timer_expires(|process| Term::local_reference(process));
+    with_message_does_not_panic_when_timer_expires(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4.rs
@@ -10,7 +10,7 @@ fn with_atom_options_errors_badarg() {
 
 #[test]
 fn with_local_reference_options_errors_badarg() {
-    with_options_errors_badarg(|process| Term::local_reference(&process));
+    with_options_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options.rs
@@ -17,7 +17,7 @@ fn with_atom_time_errors_badarg() {
 
 #[test]
 fn with_local_reference_time_errors_badarg() {
-    with_time_errors_badarg(|process| Term::local_reference(&process));
+    with_time_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -107,14 +109,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once/with_local_pid_destination/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once/with_local_pid_destination/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/at_once/with_local_pid_destination/without_process.rs
@@ -22,7 +22,7 @@ fn with_big_integer_message_does_not_panic_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_does_not_panic_when_timer_expires() {
-    with_message_does_not_panic_when_timer_expires(|process| Term::local_reference(process));
+    with_message_does_not_panic_when_timer_expires(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -107,14 +109,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later/with_local_pid_destination/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later/with_local_pid_destination/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/later/with_local_pid_destination/without_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -107,14 +109,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term/with_local_pid_destination/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term/with_local_pid_destination/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/long_term/with_local_pid_destination/without_process.rs
@@ -22,7 +22,7 @@ fn with_big_integer_message_does_not_panic_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_does_not_panic_when_timer_expires() {
-    with_message_does_not_panic_when_timer_expires(|process| Term::local_reference(process));
+    with_message_does_not_panic_when_timer_expires(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -107,14 +109,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon/with_local_pid_destination/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon/with_local_pid_destination/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_empty_list_options/with_small_integer_time/soon/with_local_pid_destination/without_process.rs
@@ -22,7 +22,7 @@ fn with_big_integer_message_does_not_panic_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_does_not_panic_when_timer_expires() {
-    with_message_does_not_panic_when_timer_expires(|process| Term::local_reference(process));
+    with_message_does_not_panic_when_timer_expires(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs.rs
@@ -19,7 +19,7 @@ fn with_big_integer_errors_badarg() {
 
 #[test]
 fn with_local_reference_abs_errors_badarg() {
-    with_abs_errors_badarg(|process| Term::local_reference(process));
+    with_abs_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false.rs
@@ -17,7 +17,7 @@ fn with_atom_time_errors_badarg() {
 
 #[test]
 fn with_local_reference_time_errors_badarg() {
-    with_time_errors_badarg(|process| Term::local_reference(&process));
+    with_time_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -107,14 +109,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once/with_local_pid_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once/with_local_pid_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/at_once/with_local_pid_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -107,14 +109,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later/with_local_pid_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later/with_local_pid_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/later/with_local_pid_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -107,14 +109,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term/with_local_pid_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term/with_local_pid_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/long_term/with_local_pid_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -107,14 +109,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon/with_local_pid_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon/with_local_pid_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_false/with_small_integer_time/soon/with_local_pid_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true.rs
@@ -17,7 +17,7 @@ fn with_atom_time_errors_badarg() {
 
 #[test]
 fn with_local_reference_time_errors_badarg() {
-    with_time_errors_badarg(|process| Term::local_reference(&process));
+    with_time_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
@@ -19,7 +19,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -104,14 +106,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
@@ -19,7 +19,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
@@ -19,7 +19,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once/with_local_pid_destination/registered/with_different_process.rs
@@ -19,7 +19,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -96,14 +98,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once/with_local_pid_destination/registered/with_same_process.rs
@@ -19,7 +19,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -94,14 +96,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/at_once/with_local_pid_destination/unregistered.rs
@@ -19,7 +19,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -107,14 +109,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later/with_local_pid_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later/with_local_pid_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/later/with_local_pid_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -107,14 +109,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term/with_local_pid_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term/with_local_pid_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/long_term/with_local_pid_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -107,14 +109,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon/with_atom_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon/with_local_pid_destination/registered/with_different_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -99,14 +101,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&destination_process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon/with_local_pid_destination/registered/with_same_process.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -97,14 +99,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/with_true/with_small_integer_time/soon/with_local_pid_destination/unregistered.rs
@@ -22,7 +22,9 @@ fn with_big_integer_message_sends_timeout_message_when_timer_expires() {
 
 #[test]
 fn with_local_reference_message_sends_timeout_message_when_timer_expires() {
-    with_message_sends_timeout_message_when_timer_expires(|process| Term::local_reference(process));
+    with_message_sends_timeout_message_when_timer_expires(|process| {
+        Term::next_local_reference(process)
+    });
 }
 
 #[test]
@@ -102,14 +104,7 @@ where
 
         assert_eq!(unboxed_timer_reference.tag(), LocalReference);
 
-        let timeout_message = Term::slice_to_tuple(
-            &[
-                Term::str_to_atom("timeout", DoNotCare).unwrap(),
-                timer_reference,
-                message,
-            ],
-            &process_arc,
-        );
+        let timeout_message = timeout_message(timer_reference, message, &process_arc);
 
         assert!(!has_message(&process_arc, timeout_message));
 

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean.rs
@@ -17,7 +17,7 @@ fn with_atom_time_errors_badarg() {
 
 #[test]
 fn with_local_reference_time_errors_badarg() {
-    with_time_errors_badarg(|process| Term::local_reference(&process));
+    with_time_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once/with_local_pid_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once/with_local_pid_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/at_once/with_local_pid_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later/with_atom_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later/with_local_pid_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later/with_local_pid_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/later/with_local_pid_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term/with_local_pid_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term/with_local_pid_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/long_term/with_local_pid_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon/with_atom_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon/with_local_pid_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon/with_local_pid_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_abs/with_atom/without_boolean/with_small_integer_time/soon/with_local_pid_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option.rs
@@ -17,7 +17,7 @@ fn with_atom_time_errors_badarg() {
 
 #[test]
 fn with_local_reference_time_errors_badarg() {
-    with_time_errors_badarg(|process| Term::local_reference(&process));
+    with_time_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once/with_local_pid_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once/with_local_pid_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/at_once/with_local_pid_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later/with_atom_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later/with_local_pid_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later/with_local_pid_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/later/with_local_pid_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term/with_local_pid_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term/with_local_pid_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/long_term/with_local_pid_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon.rs
@@ -20,7 +20,7 @@ fn with_big_integer_destination_errors_badarg() {
 
 #[test]
 fn with_local_reference_destination_errors_badarg() {
-    with_destination_errors_badarg(|process| Term::local_reference(&process));
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon/with_atom_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon/with_local_pid_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon/with_local_pid_destination/registered/with_different_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon/with_local_pid_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon/with_local_pid_destination/registered/with_same_process.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon/with_local_pid_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_list_options/with_invalid_option/with_small_integer_time/soon/with_local_pid_destination/unregistered.rs
@@ -17,7 +17,7 @@ fn with_big_integer_message_errors_badarg() {
 
 #[test]
 fn with_local_reference_message_errors_badarg() {
-    with_message_errors_badarg(|process| Term::local_reference(process));
+    with_message_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/subtract_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/subtract_2.rs
@@ -11,7 +11,7 @@ fn with_atom_minuend_errors_badarith() {
 
 #[test]
 fn with_local_reference_minuend_errors_badarith() {
-    with_minuend_errors_badarith(|process| Term::local_reference(&process));
+    with_minuend_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/subtract_2/with_big_integer_minuend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/subtract_2/with_big_integer_minuend.rs
@@ -7,7 +7,7 @@ fn with_atom_subtrahend_errors_badarith() {
 
 #[test]
 fn with_local_reference_subtrahend_errors_badarith() {
-    with_subtrahend_errors_badarith(|process| Term::local_reference(&process));
+    with_subtrahend_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/subtract_2/with_float_minuend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/subtract_2/with_float_minuend.rs
@@ -7,7 +7,7 @@ fn with_atom_subtrahend_errors_badarith() {
 
 #[test]
 fn with_local_reference_subtrahend_errors_badarith() {
-    with_subtrahend_errors_badarith(|process| Term::local_reference(&process));
+    with_subtrahend_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/subtract_2/with_small_integer_minuend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/subtract_2/with_small_integer_minuend.rs
@@ -7,7 +7,7 @@ fn with_atom_subtrahend_errors_badarith() {
 
 #[test]
 fn with_local_reference_subtrahend_errors_badarith() {
-    with_subtrahend_errors_badarith(|process| Term::local_reference(&process));
+    with_subtrahend_errors_badarith(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/subtract_list_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/subtract_list_2.rs
@@ -18,8 +18,8 @@ fn with_atom_errors_badarg() {
 #[test]
 fn with_local_reference_errors_badarg() {
     errors_badarg(|process| {
-        let minuend = Term::local_reference(&process);
-        let subtrahend = Term::local_reference(&process);
+        let minuend = Term::next_local_reference(process);
+        let subtrahend = Term::next_local_reference(process);
 
         (minuend, subtrahend)
     });

--- a/lumen_runtime/src/otp/erlang/tests/subtract_list_2/with_empty_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/subtract_list_2/with_empty_list.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/subtract_list_2/with_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/subtract_list_2/with_list.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/throw_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/throw_1.rs
@@ -11,7 +11,7 @@ fn with_atom_throws_with_atom_reason() {
 
 #[test]
 fn with_local_reference_throws_with_local_reference() {
-    throws(|process| Term::local_reference(&process));
+    throws(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/tl_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/tl_1.rs
@@ -9,7 +9,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/tuple_size_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/tuple_size_1.rs
@@ -11,7 +11,7 @@ fn with_atom_errors_badarg() {
 
 #[test]
 fn with_local_reference_errors_badarg() {
-    errors_badarg(|process| Term::local_reference(&process));
+    errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/unregister_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/unregister_1.rs
@@ -4,7 +4,7 @@ mod with_atom_name;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/whereis_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/whereis_1.rs
@@ -4,7 +4,7 @@ mod with_atom_name;
 
 #[test]
 fn with_local_reference_name_errors_badarg() {
-    with_name_errors_badarg(|process| Term::local_reference(&process));
+    with_name_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/xor_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/xor_2.rs
@@ -10,7 +10,7 @@ fn with_atom_left_errors_badarg() {
 
 #[test]
 fn with_local_reference_left_errors_badarg() {
-    with_left_errors_badarg(|process| Term::local_reference(&process));
+    with_left_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/xor_2/with_false_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/xor_2/with_false_left.rs
@@ -21,7 +21,7 @@ fn with_true_right_returns_true() {
 
 #[test]
 fn with_local_reference_right_errors_badarg() {
-    with_right_errors_badarg(|process| Term::local_reference(&process));
+    with_right_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/otp/erlang/tests/xor_2/with_true_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/xor_2/with_true_left.rs
@@ -21,7 +21,7 @@ fn with_true_right_returns_false() {
 
 #[test]
 fn with_local_reference_right_errors_badarg() {
-    with_right_errors_badarg(|process| Term::local_reference(&process));
+    with_right_errors_badarg(|process| Term::next_local_reference(process));
 }
 
 #[test]

--- a/lumen_runtime/src/process.rs
+++ b/lumen_runtime/src/process.rs
@@ -14,6 +14,7 @@ use crate::mailbox::Mailbox;
 use crate::map::Map;
 use crate::message::Message;
 use crate::reference;
+use crate::scheduler;
 use crate::term::Term;
 use crate::tuple::Tuple;
 
@@ -29,7 +30,7 @@ pub struct Process {
 
 impl Process {
     #[cfg(test)]
-    fn new() -> Self {
+    pub fn new() -> Self {
         Process {
             pid: identifier::local::next(),
             registered_name: Default::default(),
@@ -61,13 +62,15 @@ impl Process {
         self.heap.lock().unwrap().f64_to_float(f)
     }
 
-    pub fn local_reference(&self) -> &'static reference::local::Reference {
-        self.heap.lock().unwrap().local_reference()
-    }
-
-    #[cfg(test)]
-    pub fn number_to_local_reference(&self, number: u64) -> &'static reference::local::Reference {
-        self.heap.lock().unwrap().number_to_local_reference(number)
+    pub fn local_reference(
+        &self,
+        scheduler_id: &scheduler::ID,
+        number: reference::local::Number,
+    ) -> &'static reference::local::Reference {
+        self.heap
+            .lock()
+            .unwrap()
+            .local_reference(scheduler_id, number)
     }
 
     pub fn num_bigint_big_to_big_integer(&self, big_int: BigInt) -> &'static big::Integer {
@@ -134,10 +137,6 @@ impl Process {
 
     pub fn slice_to_tuple(&self, slice: &[Term]) -> &'static Tuple {
         self.heap.lock().unwrap().slice_to_tuple(slice)
-    }
-
-    pub fn u64_to_local_reference(&self, number: u64) -> &'static reference::local::Reference {
-        self.heap.lock().unwrap().u64_to_local_reference(number)
     }
 }
 

--- a/lumen_runtime/src/reference/local.rs
+++ b/lumen_runtime/src/reference/local.rs
@@ -1,7 +1,8 @@
 use std::hash::{Hash, Hasher};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use crate::heap::{CloneIntoHeap, Heap};
+use crate::scheduler::{self, Scheduler};
 use crate::term::{Tag::LocalReference, Term};
 
 pub type Number = u64;
@@ -9,31 +10,37 @@ pub type Number = u64;
 pub struct Reference {
     #[allow(dead_code)]
     header: Term,
+    scheduler_id: scheduler::ID,
     number: Number,
 }
 
 impl Reference {
-    pub fn new(number: Number) -> Reference {
+    pub fn new(scheduler_id: &scheduler::ID, number: Number) -> Reference {
         Reference {
             header: Term {
                 tagged: LocalReference as usize,
             },
+            scheduler_id: scheduler_id.clone(),
             number,
         }
-    }
-
-    pub fn next() -> Reference {
-        Self::new(COUNT.fetch_add(1, Ordering::SeqCst))
     }
 
     pub fn number(&self) -> Number {
         self.number
     }
+
+    pub fn scheduler(&self) -> Option<Arc<Scheduler>> {
+        Scheduler::from_id(&self.scheduler_id)
+    }
+
+    pub fn scheduler_id(&self) -> scheduler::ID {
+        self.scheduler_id.clone()
+    }
 }
 
 impl CloneIntoHeap for &'static Reference {
     fn clone_into_heap(&self, heap: &Heap) -> &'static Reference {
-        heap.u64_to_local_reference(self.number)
+        heap.local_reference(&self.scheduler_id, self.number)
     }
 }
 
@@ -50,6 +57,3 @@ impl PartialEq for Reference {
         self.number == other.number
     }
 }
-
-// References are always 64-bits even on 32-bit platforms
-static COUNT: AtomicU64 = AtomicU64::new(0);

--- a/lumen_runtime/src/scheduler.rs
+++ b/lumen_runtime/src/scheduler.rs
@@ -1,0 +1,196 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock, Weak};
+
+#[cfg(test)]
+use crate::process::local::put_pid_to_process;
+use crate::process::Process;
+use crate::reference;
+use crate::term::Term;
+use crate::timer::Hierarchy;
+
+mod id;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ID(id::Raw);
+
+impl ID {
+    fn new(raw: id::Raw) -> ID {
+        ID(raw)
+    }
+}
+
+pub struct Scheduler {
+    pub id: ID,
+    pub hierarchy: Mutex<Hierarchy>,
+    pub process_by_pid: RwLock<HashMap<Term, Arc<Process>>>,
+    // References are always 64-bits even on 32-bit platforms
+    reference_count: AtomicU64,
+}
+
+impl Scheduler {
+    pub fn current() -> Arc<Scheduler> {
+        SCHEDULER.with(|thread_local_scheduler| thread_local_scheduler.clone())
+    }
+
+    pub fn from_id(id: &ID) -> Option<Arc<Scheduler>> {
+        Self::current_from_id(id).or_else(|| {
+            SCHEDULERS
+                .lock()
+                .unwrap()
+                .scheduler_by_id
+                .get(id)
+                .and_then(|arc_scheduler| arc_scheduler.upgrade())
+        })
+    }
+
+    fn current_from_id(id: &ID) -> Option<Arc<Scheduler>> {
+        SCHEDULER.with(|thread_local_scheduler| {
+            if &thread_local_scheduler.id == id {
+                Some(thread_local_scheduler.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    #[cfg(test)]
+    pub fn new_process(&self) -> Arc<Process> {
+        let process = Process::new();
+        let process_arc = Arc::new(process);
+
+        put_pid_to_process(process_arc.clone());
+
+        process_arc
+    }
+
+    pub fn next_reference_number(&self) -> reference::local::Number {
+        self.reference_count.fetch_add(1, Ordering::SeqCst)
+    }
+
+    pub fn next_reference(&self, process: &Process) -> &'static reference::local::Reference {
+        self.reference(self.next_reference_number(), process)
+    }
+
+    pub fn reference(
+        &self,
+        number: reference::local::Number,
+        process: &Process,
+    ) -> &'static reference::local::Reference {
+        process.local_reference(&self.id, number)
+    }
+
+    // Private
+
+    fn new(raw_id: id::Raw) -> Scheduler {
+        Scheduler {
+            id: ID::new(raw_id),
+            hierarchy: Default::default(),
+            process_by_pid: Default::default(),
+            reference_count: AtomicU64::new(0),
+        }
+    }
+
+    fn registered() -> Arc<Scheduler> {
+        let mut locked_schedulers = SCHEDULERS.lock().unwrap();
+        let raw_id = locked_schedulers.id_manager.alloc();
+        let arc_scheduler = Arc::new(Scheduler::new(raw_id));
+
+        if let Some(_) = locked_schedulers
+            .scheduler_by_id
+            .insert(arc_scheduler.id.clone(), Arc::downgrade(&arc_scheduler))
+        {
+            panic!(
+                "Scheduler already registered with ID ({:?}",
+                arc_scheduler.id
+            );
+        }
+
+        arc_scheduler
+    }
+}
+
+impl Drop for Scheduler {
+    fn drop(&mut self) {
+        let mut locked_schedulers = SCHEDULERS.lock().unwrap();
+
+        locked_schedulers
+            .scheduler_by_id
+            .remove(&self.id)
+            .expect("Scheduler not registered");
+        // Free the ID only after it is not registered to prevent manager re-allocating the ID to a
+        // Scheduler for a new thread.
+        locked_schedulers.id_manager.free(self.id.0)
+    }
+}
+
+thread_local! {
+  static SCHEDULER: Arc<Scheduler> = Scheduler::registered();
+}
+
+// A single struct, so that one `Mutex` can protect both the `id_manager` and `scheduler_by_id`, so
+// that schedulers are deregistered from `scheduler_by_id` before giving the `ID` back to the
+// `manager`, which is the opposite order from creation.  The opposite order means it doesn't work
+// to implement separate `Mutex`es with Drop for both `ID` and `Scheduler`.
+struct Schedulers {
+    id_manager: id::Manager,
+    // Schedulers are `Weak` so that when the spawning thread ends, `SCHEDULER` can be dropped,
+    // which will remove the entry here.
+    scheduler_by_id: HashMap<ID, Weak<Scheduler>>,
+}
+
+impl Schedulers {
+    fn new() -> Schedulers {
+        Schedulers {
+            id_manager: id::Manager::new(),
+            scheduler_by_id: Default::default(),
+        }
+    }
+}
+
+lazy_static! {
+    static ref SCHEDULERS: Mutex<Schedulers> = Mutex::new(Schedulers::new());
+}
+
+#[cfg(test)]
+pub fn with_process<F>(f: F)
+where
+    F: FnOnce(&Process) -> (),
+{
+    f(&Scheduler::current().new_process())
+}
+
+#[cfg(test)]
+pub fn with_process_arc<F>(f: F)
+where
+    F: FnOnce(Arc<Process>) -> (),
+{
+    f(Scheduler::current().new_process())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod scheduler {
+        use super::*;
+
+        mod new_process {
+            use super::*;
+
+            use crate::otp::erlang;
+
+            #[test]
+            fn different_processes_have_different_pids() {
+                let scheduler = Scheduler::current();
+                let first_process = scheduler.new_process();
+                let second_process = scheduler.new_process();
+
+                assert_ne!(
+                    erlang::self_0(&first_process),
+                    erlang::self_0(&second_process)
+                );
+            }
+        }
+    }
+}

--- a/lumen_runtime/src/scheduler/id.rs
+++ b/lumen_runtime/src/scheduler/id.rs
@@ -1,0 +1,40 @@
+// Based on https://github.com/Amanieu/thread_local-rs/blob/8c956ed8642175f1a3afc409bf5f8844d3ea994a/src/thread_id.rs
+use std::collections::BinaryHeap;
+
+// A separate type so this can be resized easily if we ever need more concurrent schedulers.
+pub type Raw = u8;
+
+// Manager which allocates scheduler IDs. It attempts to aggressively reuse scheduler IDs to allow
+// scheduler ID to keep inside the number of expected concurrent schedulers and not the total number
+// of schedulers spawned in a `cargo test` run, which is greater than or equal to the number of
+// tests as each test is run in a separate thread and some threads spawn their own threads to test
+// inter-schedule communication.
+pub struct Manager {
+    next: Raw,
+    free_heap: BinaryHeap<Raw>,
+}
+
+impl Manager {
+    pub fn new() -> Manager {
+        Manager {
+            next: 0,
+            free_heap: BinaryHeap::new(),
+        }
+    }
+
+    pub fn alloc(&mut self) -> Raw {
+        match self.free_heap.pop() {
+            Some(id) => id,
+            None => {
+                let id = self.next;
+                self.next = self.next.checked_add(1).expect("Scheduler ID overflow");
+
+                id
+            }
+        }
+    }
+
+    pub fn free(&mut self, id: Raw) {
+        self.free_heap.push(id)
+    }
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `:erlang.cancel_timer/1`

## Bug FIxes
* Timer hierarchies are no longer thread local because they need to be accessible cross-scheduler, which means cross-thread.  So that `timer::cancel_timer` can quickly find the `Hierarchy` that contains the timer, local references now contain a `scheduler::ID`, which is similar to how BEAM implements references.