### PR TITLE
:erlang.send_after/3

### DIFF
--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -104,6 +104,7 @@ mod rem_2;
 mod self_0;
 mod send_2;
 mod send_3;
+mod send_after_3;
 mod setelement_3;
 mod size_1;
 mod split_binary_2;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3.rs
@@ -1,0 +1,81 @@
+use super::*;
+
+mod with_small_integer_time;
+
+#[test]
+fn with_float_time_errors_badarg() {
+    with_time_errors_badarg(|process| 1.0.into_process(&process));
+}
+
+// BigInt is not tested because it would take too long and would always count as `long_term` for the
+// super shot soon and later wheel sizes used for `cfg(test)`
+
+#[test]
+fn with_atom_time_errors_badarg() {
+    with_time_errors_badarg(|_| Term::str_to_atom("atom", DoNotCare).unwrap());
+}
+
+#[test]
+fn with_local_reference_time_errors_badarg() {
+    with_time_errors_badarg(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_local_pid_time_errors_badarg() {
+    with_time_errors_badarg(|_| Term::local_pid(0, 0).unwrap());
+}
+
+#[test]
+fn with_external_pid_time_errors_badarg() {
+    with_time_errors_badarg(|process| Term::external_pid(1, 0, 0, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_time_errors_badarg() {
+    with_time_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_time_errors_badarg() {
+    with_time_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_empty_list_time_errors_badarg() {
+    with_time_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_time_errors_badarg() {
+    with_time_errors_badarg(|process| list_term(&process));
+}
+
+#[test]
+fn with_heap_binary_time_errors_badarg() {
+    with_time_errors_badarg(|process| Term::slice_to_binary(&[1], &process));
+}
+
+#[test]
+fn with_subbinary_time_errors_badarg() {
+    with_time_errors_badarg(|process| {
+        let original = Term::slice_to_binary(&[0, 1], &process);
+        Term::subbinary(original, 1, 0, 1, 0, &process)
+    });
+}
+
+fn with_time_errors_badarg<T>(time: T)
+where
+    T: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = process_arc.pid;
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::send_after_3(
+            time(&process_arc),
+            destination,
+            message,
+            process_arc
+        ));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time.rs
@@ -1,0 +1,6 @@
+use super::*;
+
+mod at_once;
+mod later;
+mod long_term;
+mod soon;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+mod with_atom_destination;
+mod with_local_pid_destination;
+
+#[test]
+fn with_small_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_float_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 1.0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| (integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_local_reference_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::external_pid(1, 0, 0, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_empty_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| list_term(&process));
+}
+
+#[test]
+fn with_heap_binary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_binary(&[1], &process));
+}
+
+#[test]
+fn with_subbinary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| {
+        let original = Term::slice_to_binary(&[0, 1], &process);
+        Term::subbinary(original, 1, 0, 1, 0, &process)
+    });
+}
+
+fn milliseconds() -> u64 {
+    timer::at_once_milliseconds()
+}
+
+fn with_destination_errors_badarg<D>(destination: D)
+where
+    D: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let time = milliseconds().into_process(&process_arc);
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::send_after_3(
+            time,
+            destination(&process_arc),
+            message,
+            process_arc
+        ));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_atom_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_atom_destination.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod registered;
+mod unregistered;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_atom_destination/registered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_atom_destination/registered.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_atom_destination/registered/with_different_process.rs
@@ -1,0 +1,110 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination_process_arc = process::local::new();
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(
+                destination,
+                destination_process_arc.pid,
+                process_arc.clone()
+            ),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&destination_process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_atom_destination/registered/with_same_process.rs
@@ -1,0 +1,105 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_atom_destination/unregistered.rs
@@ -1,0 +1,105 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_local_pid_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_local_pid_destination.rs
@@ -1,0 +1,5 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;
+mod without_process;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_local_pid_destination/with_different_process.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination_process_arc = process::local::new();
+        let destination = destination_process_arc.pid;
+
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&destination_process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_local_pid_destination/with_same_process.rs
@@ -1,0 +1,99 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination = process_arc.pid;
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/at_once/with_local_pid_destination/without_process.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| (integer::small::MAX + 1).into_process(process));
+}
+
+#[test]
+fn with_local_reference_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| Term::external_pid(1, 0, 0, process).unwrap());
+}
+
+#[test]
+fn with_tuple_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_does_not_panic_when_timer_expires() {
+    does_not_panic_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn does_not_panic_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = process::identifier::local::next();
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        // does not send to original process either
+        assert!(!has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+mod with_atom_destination;
+mod with_local_pid_destination;
+
+#[test]
+fn with_small_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_float_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 1.0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| (integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_local_reference_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::external_pid(1, 0, 0, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_empty_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| list_term(&process));
+}
+
+#[test]
+fn with_heap_binary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_binary(&[1], &process));
+}
+
+#[test]
+fn with_subbinary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| {
+        let original = Term::slice_to_binary(&[0, 1], &process);
+        Term::subbinary(original, 1, 0, 1, 0, &process)
+    });
+}
+
+fn milliseconds() -> u64 {
+    timer::later_milliseconds()
+}
+
+fn with_destination_errors_badarg<D>(destination: D)
+where
+    D: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let time = milliseconds().into_process(&process_arc);
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::send_after_3(
+            time,
+            destination(&process_arc),
+            message,
+            process_arc
+        ));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_atom_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_atom_destination.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod registered;
+mod unregistered;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_atom_destination/registered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_atom_destination/registered.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_atom_destination/registered/with_different_process.rs
@@ -1,0 +1,110 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination_process_arc = process::local::new();
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(
+                destination,
+                destination_process_arc.pid,
+                process_arc.clone()
+            ),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&destination_process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_atom_destination/registered/with_same_process.rs
@@ -1,0 +1,105 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_atom_destination/unregistered.rs
@@ -1,0 +1,105 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_local_pid_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_local_pid_destination.rs
@@ -1,0 +1,5 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;
+mod without_process;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_local_pid_destination/with_different_process.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination_process_arc = process::local::new();
+        let destination = destination_process_arc.pid;
+
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&destination_process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_local_pid_destination/with_same_process.rs
@@ -1,0 +1,100 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination = process_arc.pid;
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/later/with_local_pid_destination/without_process.rs
@@ -1,0 +1,98 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_does_not_panic_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = process::identifier::local::next();
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        // does not send to original process either
+        assert!(!has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+mod with_atom_destination;
+mod with_local_pid_destination;
+
+#[test]
+fn with_small_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_float_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 1.0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| (integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_local_reference_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::external_pid(1, 0, 0, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_empty_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| list_term(&process));
+}
+
+#[test]
+fn with_heap_binary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_binary(&[1], &process));
+}
+
+#[test]
+fn with_subbinary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| {
+        let original = Term::slice_to_binary(&[0, 1], &process);
+        Term::subbinary(original, 1, 0, 1, 0, &process)
+    });
+}
+
+fn milliseconds() -> u64 {
+    timer::long_term_milliseconds()
+}
+
+fn with_destination_errors_badarg<D>(destination: D)
+where
+    D: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let time = milliseconds().into_process(&process_arc);
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::send_after_3(
+            time,
+            destination(&process_arc),
+            message,
+            process_arc
+        ));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_atom_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_atom_destination.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod registered;
+mod unregistered;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_atom_destination/registered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_atom_destination/registered.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_atom_destination/registered/with_different_process.rs
@@ -1,0 +1,110 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination_process_arc = process::local::new();
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(
+                destination,
+                destination_process_arc.pid,
+                process_arc.clone()
+            ),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&destination_process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_atom_destination/registered/with_same_process.rs
@@ -1,0 +1,105 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_atom_destination/unregistered.rs
@@ -1,0 +1,105 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_local_pid_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_local_pid_destination.rs
@@ -1,0 +1,5 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;
+mod without_process;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_local_pid_destination/with_different_process.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination_process_arc = process::local::new();
+        let destination = destination_process_arc.pid;
+
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&destination_process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_local_pid_destination/with_same_process.rs
@@ -1,0 +1,100 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination = process_arc.pid;
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/long_term/with_local_pid_destination/without_process.rs
@@ -1,0 +1,98 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_does_not_panic_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = process::identifier::local::next();
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        // does not send to original process either
+        assert!(!has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+mod with_atom_destination;
+mod with_local_pid_destination;
+
+#[test]
+fn with_small_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 0.into_process(&process));
+}
+
+#[test]
+fn with_float_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| 1.0.into_process(&process));
+}
+
+#[test]
+fn with_big_integer_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| (integer::small::MAX + 1).into_process(&process));
+}
+
+#[test]
+fn with_local_reference_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::external_pid(1, 0, 0, &process).unwrap());
+}
+
+#[test]
+fn with_tuple_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_tuple(&[], &process));
+}
+
+#[test]
+fn with_map_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_map(&[], &process));
+}
+
+#[test]
+fn with_empty_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| list_term(&process));
+}
+
+#[test]
+fn with_heap_binary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| Term::slice_to_binary(&[1], &process));
+}
+
+#[test]
+fn with_subbinary_destination_errors_badarg() {
+    with_destination_errors_badarg(|process| {
+        let original = Term::slice_to_binary(&[0, 1], &process);
+        Term::subbinary(original, 1, 0, 1, 0, &process)
+    });
+}
+
+fn milliseconds() -> u64 {
+    timer::soon_milliseconds()
+}
+
+fn with_destination_errors_badarg<D>(destination: D)
+where
+    D: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let time = milliseconds().into_process(&process_arc);
+        let message = Term::str_to_atom("message", DoNotCare).unwrap();
+
+        assert_badarg!(erlang::send_after_3(
+            time,
+            destination(&process_arc),
+            message,
+            process_arc
+        ));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_atom_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_atom_destination.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod registered;
+mod unregistered;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_atom_destination/registered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_atom_destination/registered.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_atom_destination/registered/with_different_process.rs
@@ -1,0 +1,109 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination_process_arc = process::local::new();
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(
+                destination,
+                destination_process_arc.pid,
+                process_arc.clone()
+            ),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&destination_process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_atom_destination/registered/with_same_process.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_atom_destination/unregistered.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_atom_destination/unregistered.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_local_pid_destination.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_local_pid_destination.rs
@@ -1,0 +1,5 @@
+use super::*;
+
+mod with_different_process;
+mod with_same_process;
+mod without_process;

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_local_pid_destination/with_different_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_local_pid_destination/with_different_process.rs
@@ -1,0 +1,101 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination_process_arc = process::local::new();
+        let destination = destination_process_arc.pid;
+
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&destination_process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        assert!(has_message(&destination_process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_local_pid_destination/with_same_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_local_pid_destination/with_same_process.rs
@@ -1,0 +1,99 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_sends_message_when_timer_expires() {
+    with_message_sends_message_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_sends_message_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+
+        let destination = process_arc.pid;
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_local_pid_destination/without_process.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_3/with_small_integer_time/soon/with_local_pid_destination/without_process.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn with_small_integer_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| 0.into_process(process));
+}
+
+#[test]
+fn with_float_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| 1.0.into_process(process));
+}
+
+#[test]
+fn with_big_integer_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| {
+        (integer::small::MAX + 1).into_process(process)
+    });
+}
+
+#[test]
+fn with_local_reference_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::next_local_reference(process));
+}
+
+#[test]
+fn with_external_pid_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| {
+        Term::external_pid(1, 0, 0, process).unwrap()
+    });
+}
+
+#[test]
+fn with_tuple_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_tuple(&[], process));
+}
+
+#[test]
+fn with_map_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_map(&[], process));
+}
+
+#[test]
+fn with_empty_list_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|_| Term::EMPTY_LIST);
+}
+
+#[test]
+fn with_list_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| list_term(process));
+}
+
+#[test]
+fn with_heap_binary_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| Term::slice_to_binary(&[1], process));
+}
+
+#[test]
+fn with_subbinary_message_does_not_panic_when_timer_expires() {
+    with_message_does_not_panic_when_timer_expires(|process| bitstring!(1 :: 1, process));
+}
+
+fn with_message_does_not_panic_when_timer_expires<M>(message: M)
+where
+    M: FnOnce(&Process) -> Term,
+{
+    with_process_arc(|process_arc| {
+        let destination = registered_name();
+
+        assert_eq!(
+            erlang::register_2(destination, process_arc.pid, process_arc.clone()),
+            Ok(true.into())
+        );
+
+        let milliseconds = milliseconds();
+        let time = milliseconds.into_process(&process_arc);
+        let message = message(&process_arc);
+
+        let result = erlang::send_after_3(time, destination, message, process_arc.clone());
+
+        assert!(
+            result.is_ok(),
+            "Timer reference not returned.  Got {:?}",
+            result
+        );
+
+        let timer_reference = result.unwrap();
+
+        assert_eq!(timer_reference.tag(), Boxed);
+
+        let unboxed_timer_reference: &Term = timer_reference.unbox_reference();
+
+        assert_eq!(unboxed_timer_reference.tag(), LocalReference);
+
+        assert!(!has_message(&process_arc, message));
+
+        thread::sleep(Duration::from_millis(milliseconds + 1));
+        timer::timeout();
+
+        assert!(has_message(&process_arc, message));
+    })
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* `:erlang.send_after/3`

  `send_after/3` is the same as `start_timer/3`, but the message sent on timeout is `message` alone instead of `{:timeout, timer_reference, message}`, so `send_after` and `start_timer` implementation can be combined by recording the `Timeout` type as either `Message` or `TimeoutTuple`.