### PR TITLE
wasm32_linux_examples_spawn_chain_deploy

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/rust:latest-browsers
+FROM circleci/rust:latest-node-browsers
 
 RUN rustup default nightly
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,19 +159,19 @@ jobs:
             wasm-pack --version | tee wasm-pack.version
       - restore_cache:
           keys:
-            - v6-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}-cargo-{{ checksum "cargo.version" }}-lock-{{ checksum "Cargo.lock" }}-wasm-pack-{{ checksum "wasm-pack.version" }}
-            - v6-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}-cargo-{{ checksum "cargo.version" }}-lock-{{ checksum "Cargo.lock" }}
-            - v6-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}-cargo-{{ checksum "cargo.version" }}
-            - v6-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}
-            - v6-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}
-            - v6-wasm32-example-spawn-chain-{{ arch }}
+            - v7-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}-cargo-{{ checksum "cargo.version" }}-lock-{{ checksum "Cargo.lock" }}-wasm-pack-{{ checksum "wasm-pack.version" }}
+            - v7-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}-cargo-{{ checksum "cargo.version" }}-lock-{{ checksum "Cargo.lock" }}
+            - v7-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}-cargo-{{ checksum "cargo.version" }}
+            - v7-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}
+            - v7-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}
+            - v7-wasm32-example-spawn-chain-{{ arch }}
       - run:
           name: Build tests
           working_directory: "examples/spawn-chain"
           # `--no-run` for `test` will only do build
           command: wasm-pack test --chrome --firefox --headless -- --no-run
       - save_cache:
-          key: v6-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}-cargo-{{ checksum "cargo.version" }}-lock-{{ checksum "Cargo.lock" }}-wasm-pack-{{ checksum "wasm-pack.version" }}
+          key: v7-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}-cargo-{{ checksum "cargo.version" }}-lock-{{ checksum "Cargo.lock" }}-wasm-pack-{{ checksum "wasm-pack.version" }}
           paths:
             - cargo
             - target
@@ -211,6 +211,50 @@ jobs:
           name: Test in << parameters.browser >>
           working_directory: "examples/spawn-chain"
           command: wasm-pack test --<< parameters.browser >> --headless
+  wasm32_linux_examples_spawn_chain_deploy:
+    executor: x86_64_linux
+    steps:
+      - checkout
+      - version_information
+      - run:
+          name: wasm-pack version
+          command: |
+            wasm-pack --version | tee wasm-pack.version
+      - restore_cache:
+          keys:
+            - v7-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}-cargo-{{ checksum "cargo.version" }}-lock-{{ checksum "Cargo.lock" }}-wasm-pack-{{ checksum "wasm-pack.version" }}
+            - v7-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}-cargo-{{ checksum "cargo.version" }}-lock-{{ checksum "Cargo.lock" }}
+            - v7-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}-cargo-{{ checksum "cargo.version" }}
+            - v7-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}
+            - v7-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}
+            - v7-wasm32-example-spawn-chain-{{ arch }}
+      - run:
+         name: Build WebAssembly
+         working_directory: "examples/spawn-chain"
+         command: wasm-pack build
+      - save_cache:
+          key: v7-wasm32-example-spawn-chain-{{ arch }}-rustup-{{ checksum "rustup.version" }}-rustc-{{ checksum "rustc.version" }}-cargo-{{ checksum "cargo.version" }}-lock-{{ checksum "Cargo.lock" }}-wasm-pack-{{ checksum "wasm-pack.version" }}
+          paths:
+            - cargo
+            - examples/spawn-chain/pkg
+            - target
+      - run:
+         name: Pack distribution
+         working_directory: "examples/spawn-chain"
+         command: |
+           pushd www
+           npm install
+           popd
+           pushd pkg
+           sudo npm link
+           popd
+           pushd www
+           sudo npm link spawn-chain
+           npm run build
+           popd
+      - store_artifacts:
+         path: "examples/spawn-chain/www/dist"
+         destination: "demos/spawn-chain"
 workflows:
   version: 2
   primary:
@@ -271,4 +315,5 @@ workflows:
           requires:
             - wasm32_linux_examples_spawn_chain_build
           browser: firefox
+      - wasm32_linux_examples_spawn_chain_deploy
 

--- a/examples/spawn-chain/www/package-lock.json
+++ b/examples/spawn-chain/www/package-lock.json
@@ -6030,6 +6030,15 @@
         "uuid": "^3.3.2"
       }
     },
+    "webpack-merge": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
+      "integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5"
+      }
+    },
     "webpack-sources": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",

--- a/examples/spawn-chain/www/package.json
+++ b/examples/spawn-chain/www/package.json
@@ -4,13 +4,14 @@
   "description": "create an app to consume rust-generated wasm packages",
   "main": "index.js",
   "scripts": {
-    "build": "webpack --config webpack.config.js",
-    "start": "webpack-dev-server"
+    "build": "webpack --config webpack.prod.js",
+    "start": "webpack-dev-server --config webpack.dev.js"
   },
   "devDependencies": {
+    "copy-webpack-plugin": "^5.0.0",
     "webpack": "^4.29.3",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.5",
-    "copy-webpack-plugin": "^5.0.0"
+    "webpack-merge": "^4.2.1"
   }
 }

--- a/examples/spawn-chain/www/webpack.common.js
+++ b/examples/spawn-chain/www/webpack.common.js
@@ -7,7 +7,6 @@ module.exports = {
     path: path.resolve(__dirname, "dist"),
     filename: "bootstrap.js",
   },
-  mode: "development",
   plugins: [
     new CopyWebpackPlugin(['index.html'])
   ],

--- a/examples/spawn-chain/www/webpack.dev.js
+++ b/examples/spawn-chain/www/webpack.dev.js
@@ -1,0 +1,6 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'development'
+});

--- a/examples/spawn-chain/www/webpack.prod.js
+++ b/examples/spawn-chain/www/webpack.prod.js
@@ -1,0 +1,6 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'production'
+});


### PR DESCRIPTION
Store artifact of the webpacker packed:
* bootstrap.ks
* wasm file
* index.html

This way it can be retrieved by others at `demos/spawn-chain` in the CircleCI Artifacts tab to try from there or uploaded later to getlumen.org.