### PR TITLE
:maps.is_key/2

### DIFF
--- a/lumen_runtime/src/otp.rs
+++ b/lumen_runtime/src/otp.rs
@@ -3,4 +3,5 @@
 pub mod binary;
 pub mod erlang;
 pub mod lists;
+pub mod maps;
 pub mod timer;

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -7,6 +7,7 @@ pub mod demonitor_2;
 pub mod exit_1;
 pub mod is_function_1;
 pub mod is_function_2;
+pub mod is_map_key_2;
 pub mod link_1;
 pub mod monitor_2;
 pub mod monotonic_time_0;
@@ -927,15 +928,6 @@ pub fn is_list_1(term: Term) -> Term {
 
 pub fn is_map_1(term: Term) -> Term {
     term.is_map().into()
-}
-
-pub fn is_map_key_2(key: Term, map: Term, process_control_block: &ProcessControlBlock) -> Result {
-    let result: core::result::Result<Boxed<Map>, _> = map.try_into();
-
-    match result {
-        Ok(map_header) => Ok(map_header.is_key(key).into()),
-        Err(_) => Err(badmap!(process_control_block, map)),
-    }
 }
 
 pub fn is_number_1(term: Term) -> Term {

--- a/lumen_runtime/src/otp/erlang/is_map_key_2.rs
+++ b/lumen_runtime/src/otp/erlang/is_map_key_2.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use liblumen_alloc::erts::exception::system::Alloc;
+use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
+use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::term::{Atom, Term};
+use liblumen_alloc::ModuleFunctionArity;
+
+use crate::otp::maps;
+
+pub fn place_frame_with_arguments(
+    process: &ProcessControlBlock,
+    placement: Placement,
+    key: Term,
+    map: Term,
+) -> Result<(), Alloc> {
+    process.stack_push(map)?;
+    process.stack_push(key)?;
+    process.place_frame(frame(), placement);
+
+    Ok(())
+}
+
+// Private
+
+fn frame() -> Frame {
+    Frame::new(module_function_arity(), maps::is_key_2::code)
+}
+
+fn function() -> Atom {
+    Atom::try_from_str("is_map_key").unwrap()
+}
+
+fn module_function_arity() -> Arc<ModuleFunctionArity> {
+    Arc::new(ModuleFunctionArity {
+        module: super::module(),
+        function: function(),
+        arity: 2,
+    })
+}

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -72,7 +72,6 @@ mod is_integer_1;
 mod is_less_than_2;
 mod is_list_1;
 mod is_map_1;
-mod is_map_key_2;
 mod is_number_1;
 mod is_pid_1;
 mod is_record_2;

--- a/lumen_runtime/src/otp/maps.rs
+++ b/lumen_runtime/src/otp/maps.rs
@@ -1,0 +1,7 @@
+pub mod is_key_2;
+
+use liblumen_alloc::erts::term::Atom;
+
+fn module() -> Atom {
+    Atom::try_from_str("maps").unwrap()
+}

--- a/lumen_runtime/src/otp/maps/is_key_2.rs
+++ b/lumen_runtime/src/otp/maps/is_key_2.rs
@@ -1,0 +1,75 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use std::convert::TryInto;
+use std::sync::Arc;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::exception::system::Alloc;
+use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
+use liblumen_alloc::erts::process::code::{self, result_from_exception};
+use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::term::{Atom, Boxed, Map, Term};
+use liblumen_alloc::{badmap, ModuleFunctionArity};
+
+pub fn place_frame_with_arguments(
+    process: &ProcessControlBlock,
+    placement: Placement,
+    key: Term,
+    map: Term,
+) -> Result<(), Alloc> {
+    process.stack_push(map)?;
+    process.stack_push(key)?;
+    process.place_frame(frame(), placement);
+
+    Ok(())
+}
+
+// Crate Public
+
+pub(in crate::otp) fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+    arc_process.reduce();
+
+    let key = arc_process.stack_pop().unwrap();
+    let map = arc_process.stack_pop().unwrap();
+
+    match native(arc_process, key, map) {
+        Ok(boolean) => {
+            arc_process.return_from_call(boolean)?;
+
+            ProcessControlBlock::call_code(arc_process)
+        }
+        Err(exception) => result_from_exception(arc_process, exception),
+    }
+}
+
+// Private
+
+fn frame() -> Frame {
+    Frame::new(module_function_arity(), code)
+}
+
+fn function() -> Atom {
+    Atom::try_from_str("is_key").unwrap()
+}
+
+fn module_function_arity() -> Arc<ModuleFunctionArity> {
+    Arc::new(ModuleFunctionArity {
+        module: super::module(),
+        function: function(),
+        arity: 2,
+    })
+}
+
+fn native(process: &ProcessControlBlock, key: Term, map: Term) -> exception::Result {
+    let result_map: Result<Boxed<Map>, _> = map.try_into();
+
+    match result_map {
+        Ok(map) => Ok(map.is_key(key).into()),
+        Err(_) => Err(badmap!(process, map)),
+    }
+}

--- a/lumen_runtime/src/otp/maps/is_key_2/test.rs
+++ b/lumen_runtime/src/otp/maps/is_key_2/test.rs
@@ -1,0 +1,33 @@
+mod with_map;
+
+use proptest::prop_assert_eq;
+use proptest::strategy::Strategy;
+use proptest::test_runner::{Config, TestRunner};
+
+use liblumen_alloc::badmap;
+
+use crate::otp::maps::is_key_2::native;
+use crate::scheduler::with_process_arc;
+use crate::test::strategy;
+
+#[test]
+fn without_map_errors_badmap() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &(
+                    strategy::term(arc_process.clone()),
+                    strategy::term::is_not_map(arc_process.clone()),
+                ),
+                |(key, map)| {
+                    prop_assert_eq!(
+                        native(&arc_process, key, map),
+                        Err(badmap!(&arc_process, map))
+                    );
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/maps/is_key_2/test/with_map.rs
+++ b/lumen_runtime/src/otp/maps/is_key_2/test/with_map.rs
@@ -1,31 +1,9 @@
 use super::*;
 
-use proptest::strategy::Strategy;
+use liblumen_alloc::erts::term::atom_unchecked;
 
 #[test]
-fn without_map_errors_badmap() {
-    with_process_arc(|arc_process| {
-        TestRunner::new(Config::with_source_file(file!()))
-            .run(
-                &(
-                    strategy::term(arc_process.clone()),
-                    strategy::term::is_not_map(arc_process.clone()),
-                ),
-                |(key, map)| {
-                    prop_assert_eq!(
-                        erlang::is_map_key_2(key, map, &arc_process),
-                        Err(badmap!(&arc_process, map))
-                    );
-
-                    Ok(())
-                },
-            )
-            .unwrap();
-    });
-}
-
-#[test]
-fn with_map_without_key_returns_false() {
+fn without_key_returns_false() {
     with_process_arc(|arc_process| {
         TestRunner::new(Config::with_source_file(file!()))
             .run(
@@ -45,10 +23,7 @@ fn with_map_without_key_returns_false() {
                         )
                     }),
                 |(key, map)| {
-                    prop_assert_eq!(
-                        erlang::is_map_key_2(key, map, &arc_process),
-                        Ok(false.into())
-                    );
+                    prop_assert_eq!(native(&arc_process, key, map), Ok(false.into()));
 
                     Ok(())
                 },
@@ -58,7 +33,7 @@ fn with_map_without_key_returns_false() {
 }
 
 #[test]
-fn with_map_with_key_returns_true() {
+fn with_key_returns_true() {
     with_process_arc(|arc_process| {
         TestRunner::new(Config::with_source_file(file!()))
             .run(
@@ -68,10 +43,7 @@ fn with_map_with_key_returns_true() {
                     (key, arc_process.map_from_slice(&[(key, value)]).unwrap())
                 }),
                 |(key, map)| {
-                    prop_assert_eq!(
-                        erlang::is_map_key_2(key, map, &arc_process),
-                        Ok(true.into())
-                    );
+                    prop_assert_eq!(native(&arc_process, key, map), Ok(true.into()));
 
                     Ok(())
                 },


### PR DESCRIPTION
Resolves #248

# Changelog
* `:maps.is_key/2`
  * Convert `:erlang.is_map_key/2` to use `maps::is_key_2` `code` and `native`.
  * Move tests for `:erlang.is_map_key/2` into maps::is_key_2::test` since it owns the `native` that is being tested