### PR TITLE
:maps.merge/2

### DIFF
--- a/liblumen_alloc/src/erts/process.rs
+++ b/liblumen_alloc/src/erts/process.rs
@@ -535,6 +535,10 @@ impl ProcessControlBlock {
         self.acquire_heap().improper_list_from_slice(slice, tail)
     }
 
+    pub fn map_from_hash_map(&self, hash_map: HashMap<Term, Term>) -> Result<Term, Alloc> {
+        self.acquire_heap().map_from_hash_map(hash_map)
+    }
+
     pub fn map_from_slice(&self, slice: &[(Term, Term)]) -> Result<Term, Alloc> {
         self.acquire_heap().map_from_slice(slice)
     }

--- a/liblumen_alloc/src/erts/process/alloc/heap_alloc.rs
+++ b/liblumen_alloc/src/erts/process/alloc/heap_alloc.rs
@@ -7,6 +7,8 @@ use core::str::Chars;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
+use hashbrown::HashMap;
+
 use liblumen_core::util::reference::bytes;
 use liblumen_core::util::reference::str::inherit_lifetime as inherit_str_lifetime;
 
@@ -332,6 +334,14 @@ pub trait HeapAlloc {
 
     fn list_from_slice(&mut self, slice: &[Term]) -> Result<Term, Alloc> {
         self.improper_list_from_slice(slice, Term::NIL)
+    }
+
+    /// Constructs a map and associated with the given process.
+    fn map_from_hash_map(&mut self, hash_map: HashMap<Term, Term>) -> Result<Term, Alloc>
+    where
+        Self: core::marker::Sized,
+    {
+        Map::from_hash_map(hash_map).clone_to_heap(self)
     }
 
     /// Constructs a map and associated with the given process.

--- a/lumen_runtime/src/otp/maps.rs
+++ b/lumen_runtime/src/otp/maps.rs
@@ -1,4 +1,5 @@
 pub mod is_key_2;
+pub mod merge_2;
 
 use liblumen_alloc::erts::term::Atom;
 

--- a/lumen_runtime/src/otp/maps/merge_2.rs
+++ b/lumen_runtime/src/otp/maps/merge_2.rs
@@ -1,0 +1,102 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use std::convert::TryInto;
+use std::sync::Arc;
+
+use hashbrown::HashMap;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::exception::system::Alloc;
+use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
+use liblumen_alloc::erts::process::code::{self, result_from_exception};
+use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::term::{Atom, Boxed, Map, Term};
+use liblumen_alloc::{badmap, ModuleFunctionArity};
+
+pub fn place_frame_with_arguments(
+    process: &ProcessControlBlock,
+    placement: Placement,
+    map1: Term,
+    map2: Term,
+) -> Result<(), Alloc> {
+    process.stack_push(map2)?;
+    process.stack_push(map1)?;
+    process.place_frame(frame(), placement);
+
+    Ok(())
+}
+
+// Crate Public
+
+pub(in crate::otp) fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+    arc_process.reduce();
+
+    let map1 = arc_process.stack_pop().unwrap();
+    let map2 = arc_process.stack_pop().unwrap();
+
+    match native(arc_process, map1, map2) {
+        Ok(map3) => {
+            arc_process.return_from_call(map3)?;
+
+            ProcessControlBlock::call_code(arc_process)
+        }
+        Err(exception) => result_from_exception(arc_process, exception),
+    }
+}
+
+// Private
+
+fn frame() -> Frame {
+    Frame::new(module_function_arity(), code)
+}
+
+fn function() -> Atom {
+    Atom::try_from_str("merge").unwrap()
+}
+
+fn module_function_arity() -> Arc<ModuleFunctionArity> {
+    Arc::new(ModuleFunctionArity {
+        module: super::module(),
+        function: function(),
+        arity: 2,
+    })
+}
+
+fn native(process: &ProcessControlBlock, map1: Term, map2: Term) -> exception::Result {
+    let result_map1: Result<Boxed<Map>, _> = map1.try_into();
+
+    match result_map1 {
+        Ok(map1) => {
+            let result_map2: Result<Boxed<Map>, _> = map2.try_into();
+
+            match result_map2 {
+                Ok(map2) => {
+                    let hash_map1: &HashMap<_, _> = map1.as_ref();
+                    let hash_map2: &HashMap<_, _> = map2.as_ref();
+
+                    let mut hash_map3: HashMap<Term, Term> =
+                        HashMap::with_capacity(hash_map1.len() + hash_map2.len());
+
+                    for (key, value) in hash_map1 {
+                        hash_map3.insert(*key, *value);
+                    }
+
+                    for (key, value) in hash_map2 {
+                        hash_map3.insert(*key, *value);
+                    }
+
+                    process
+                        .map_from_hash_map(hash_map3)
+                        .map_err(|error| error.into())
+                }
+                Err(_) => Err(badmap!(process, map2)),
+            }
+        }
+        Err(_) => Err(badmap!(process, map1)),
+    }
+}

--- a/lumen_runtime/src/otp/maps/merge_2/test.rs
+++ b/lumen_runtime/src/otp/maps/merge_2/test.rs
@@ -1,0 +1,33 @@
+mod with_map_map1;
+
+use proptest::prop_assert_eq;
+use proptest::strategy::{Just, Strategy};
+use proptest::test_runner::{Config, TestRunner};
+
+use liblumen_alloc::badmap;
+
+use crate::otp::maps::merge_2::native;
+use crate::test::strategy;
+
+#[test]
+fn without_map_map_1_errors_badmap() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    strategy::term::is_not_map(arc_process.clone()),
+                    strategy::term::is_map(arc_process.clone()),
+                )
+            }),
+            |(arc_process, map1, map2)| {
+                prop_assert_eq!(
+                    native(&arc_process, map1, map2),
+                    Err(badmap!(&arc_process, map1))
+                );
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}

--- a/lumen_runtime/src/otp/maps/merge_2/test/with_map_map1.rs
+++ b/lumen_runtime/src/otp/maps/merge_2/test/with_map_map1.rs
@@ -1,0 +1,26 @@
+mod with_map_map2;
+
+use super::*;
+
+#[test]
+fn without_map_map2_errors_badmap() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    strategy::term::is_map(arc_process.clone()),
+                    strategy::term::is_not_map(arc_process.clone()),
+                )
+            }),
+            |(arc_process, map1, map2)| {
+                prop_assert_eq!(
+                    native(&arc_process, map1, map2),
+                    Err(badmap!(&arc_process, map2))
+                );
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}

--- a/lumen_runtime/src/otp/maps/merge_2/test/with_map_map1/with_map_map2.rs
+++ b/lumen_runtime/src/otp/maps/merge_2/test/with_map_map1/with_map_map2.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+use std::convert::TryInto;
+
+use proptest::prop_assert;
+use proptest::strategy::Just;
+
+use liblumen_alloc::erts::term::{Boxed, Map};
+
+#[test]
+fn with_same_key_in_map1_and_map2_uses_value_from_map2() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    strategy::term(arc_process.clone()),
+                    strategy::term(arc_process.clone()),
+                    strategy::term(arc_process.clone()),
+                )
+            }),
+            |(arc_process, key, value1, value2)| {
+                let map1 = arc_process.map_from_slice(&[(key, value1)]).unwrap();
+                let map2 = arc_process.map_from_slice(&[(key, value2)]).unwrap();
+
+                let result_map3 = native(&arc_process, map1, map2);
+
+                prop_assert!(result_map3.is_ok());
+
+                let map3 = result_map3.unwrap();
+
+                let map3_map: Boxed<Map> = map3.try_into().unwrap();
+
+                prop_assert_eq!(map3_map.get(key), Some(value2));
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn with_different_keys_in_map2_and_map2_combines_keys() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process()
+                .prop_flat_map(|arc_process| {
+                    (Just(arc_process.clone()), strategy::term(arc_process))
+                })
+                .prop_flat_map(|(arc_process, key1)| {
+                    (
+                        Just(arc_process.clone()),
+                        Just(key1),
+                        strategy::term(arc_process)
+                            .prop_filter("Key1 and Key2 must be different", move |key2| {
+                                *key2 != key1
+                            }),
+                    )
+                })
+                .prop_flat_map(|(arc_process, key1, key2)| {
+                    (
+                        Just(arc_process.clone()),
+                        Just(key1),
+                        strategy::term(arc_process.clone()),
+                        Just(key2),
+                        strategy::term(arc_process),
+                    )
+                }),
+            |(arc_process, key1, value1, key2, value2)| {
+                let map1 = arc_process.map_from_slice(&[(key1, value1)]).unwrap();
+                let map2 = arc_process.map_from_slice(&[(key2, value2)]).unwrap();
+
+                let result_map3 = native(&arc_process, map1, map2);
+
+                prop_assert!(result_map3.is_ok());
+
+                let map3 = result_map3.unwrap();
+
+                let map3_map: Boxed<Map> = map3.try_into().unwrap();
+
+                prop_assert_eq!(map3_map.get(key1), Some(value1));
+                prop_assert_eq!(map3_map.get(key2), Some(value2));
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}


### PR DESCRIPTION
Resolves #250

* `:maps.merge/2`
* `Map.from_hash_map(HashMap<Term, Term>)` consumes the `HashMap`.
* `process.map_from_hash_map(HashMap<Term, Term>)` consumes the `HashMap`
  and copies it into the `process`.
* `HeapAlloc::map_from_hash_map(HashMap<Term, Term>)` consumes the
  `HashMap` and copies it into the `HeapAlloc`.
* `AsRef<HashMap<Term, Term>>` for `Boxed<Map>` and `Map` means you can take a `TypedTerm::Map(boxed_map)` and get the `&HashMap` out with `boxed_map.as_ref()`.