### PR TITLE
Seq<T>: Data race allowed on T

### DIFF
--- a/compiler/util/src/seq.rs
+++ b/compiler/util/src/seq.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 pub struct Seq<T> {
     vec: Option<Arc<Vec<T>>>,
 }
-unsafe impl<T> Send for Seq<T> {}
+unsafe impl<T: Send> Send for Seq<T> {}
 impl<T> Seq<T> {
     pub fn new() -> Self {
         Self::default()


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
`Seq<T>` unconditionally implements Sync. This allows users to create data races on `T: !Sync`. Such data races can lead to undefined behavior.
https://github.com/GetFirefly/firefly/blob/8e89bc7ec33cb8ffa9a60283c8dcb7ff62ead5fa/compiler/util/src/seq.rs#L10